### PR TITLE
Fix Flux not always updating releases to the latest version of the image

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -200,6 +200,7 @@ jobs:
           helm upgrade flux fluxcd/flux \
             --set git.url=git@github.com:$GITHUB_REPOSITORY \
             --set git.path="releases/$CLUSTER_ENV" \
+            --set git.tag="flux-sync-$CLUSTER_ENV" \
             --set syncGarbageCollection.enabled=true \
             --namespace flux \
             --install --wait

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -200,7 +200,7 @@ jobs:
           helm upgrade flux fluxcd/flux \
             --set git.url=git@github.com:$GITHUB_REPOSITORY \
             --set git.path="releases/$CLUSTER_ENV" \
-            --set git.tag="flux-sync-$CLUSTER_ENV" \
+            --set git.label="flux-sync-$CLUSTER_ENV" \
             --set syncGarbageCollection.enabled=true \
             --namespace flux \
             --install --wait


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
`git.label` is desrcibed in [the docs](https://github.com/fluxcd/flux/tree/master/chart/flux) for the Flux chart as the way to specify what tag a Flux instance should add to the repository to detect any changes since its last sync state. As seen [here](https://docs.fluxcd.io/en/1.17.0/faq.html#why-does-my-ci-pipeline-keep-getting-triggered) in the FAQ, this can cause issues when multiple Flux instances are accessing the same repo. This adds a separate tag for each environment so this does not happen again.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR