### PR TITLE
Add describe rights to all tables so console works with DynamoDB

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -30,6 +30,11 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
+                Action:
+                  - "dynamodb:Describe*"
+                Resource:
+                  - '*'
+              - Effect: Allow
                 Action: "dynamodb:*"
                 Resource:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/experiments-${Environment}"

--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -30,10 +30,8 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action:
-                  - "dynamodb:Describe*"
-                Resource:
-                  - '*'
+                Action: "dynamodb:Describe*"
+                Resource: '*'
               - Effect: Allow
                 Action: "dynamodb:*"
                 Resource:
@@ -78,6 +76,14 @@ Resources:
                   - "cloudformation:CreateChangeSet"
                   - "cloudformation:DeleteChangeSet"
                 Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/biomage-*-staging-*/*"
+
+        - PolicyName: !Sub "can-access-${Environment}-eks-cluster"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: 'eks:DescribeCluster'
+                Resource: !Sub "arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/biomage-${Environment}"
 
         - PolicyName: !Sub "can-manage-${Environment}-elasticache"
           PolicyDocument:


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Added `dynamodb::Describe*` rights to all tables so team members can access the console and tables without programmatic access.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR