### PR TITLE
add permissions for AWS amplify upload

### DIFF
--- a/cf/cognito.yaml
+++ b/cf/cognito.yaml
@@ -23,4 +23,4 @@ Resources:
     Properties:
       IdentityPoolId: !Ref FileUploadIdentityPool
       Roles:
-        "authenticated": "arn:aws:iam::${AWS::AccountId}:role/ui-role-${Environment}"
+        "authenticated": !Sub "arn:aws:iam::${AWS::AccountId}:role/ui-role-${Environment}"

--- a/cf/cognito.yaml
+++ b/cf/cognito.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Set up Cognito resources for Biomage SCP [managed by github.com/biomage-ltd/iac]
+
+Parameters:
+  Environment:
+    Type: String
+    Default: development
+    AllowedValues:
+      - development
+      - staging
+      - production
+    Description: The environment for which the buckets need to be created.
+
+Resources:
+  FileUploadIdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      IdentityPoolName: "file-upload-identity-pool"
+      AllowUnauthenticatedIdentities: false
+
+  FileUploadIdentityPoolRoleAttachment:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId: !Ref FileUploadIdentityPool
+      Roles:
+        "authenticated": "arn:aws:iam::${AWS::AccountId}:role/ui-role-${Environment}"

--- a/cf/irsa-ui-role.yaml
+++ b/cf/irsa-ui-role.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Set up role for the UI [managed by github.com/biomage-ltd/iac]
+
+Parameters:
+  Environment:
+    Type: String
+    Default: development
+    AllowedValues:
+      - development
+      - staging
+      - production
+    Description: The environment for which the role needs to be created.
+
+  OIDCProvider:
+    Type: String
+    Description: The OIDC provider
+
+Resources:
+  APIRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "ui-role-${Environment}"
+      AssumeRolePolicyDocument:
+        Fn::Sub: |-
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDCProvider}"
+                },
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Condition": {
+                  "StringLike": {
+                    "${OIDCProvider}:sub": "system:serviceaccount:api-*:deployment-runner"
+                  }
+                }
+              }
+            ]
+          }
+      Path: /
+      Policies:
+        - PolicyName: !Sub "can-upload-object-to-destination-bucket-${Environment}"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:PutObject"
+                  - "s3:ListMultipartUploadParts"
+                  - "s3:AbortMultipartUpload"
+                  - "s3:ListBucketMultipartUploads"
+                Resource:
+                  - !Sub "arn:aws:s3:::biomage-uploaded-samples-${Environment}/*"
+
+        - PolicyName: !Sub "can-get-object-information-in-bucket-${Environment}"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:GetObject"
+                  - "s3:GetObjectTagging"
+                Resource:
+                  - !Sub "arn:aws:s3:::biomage-uploaded-samples-${Environment}/*"
+
+        - PolicyName: !Sub "can-list-objects-in-bucket-${Environment}"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:ListBucket"
+                Resource:
+                  - !Sub "arn:aws:s3:::biomage-uploaded-samples-${Environment}"

--- a/cf/irsa-worker-role.yaml
+++ b/cf/irsa-worker-role.yaml
@@ -14,32 +14,31 @@ Parameters:
   OIDCProvider:
     Type: String
     Description: The OIDC provider
-  
+
 Resources:
   WorkerRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       RoleName: !Sub "worker-role-${Environment}"
       AssumeRolePolicyDocument:
-        Fn::Sub:
-          |-
-            {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Principal": {
-                    "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDCProvider}"
-                  },
-                  "Action": "sts:AssumeRoleWithWebIdentity",
-                  "Condition": {
-                    "StringLike": {
-                      "${OIDCProvider}:sub": "system:serviceaccount:worker-*:deployment-runner"
-                    }
+        Fn::Sub: |-
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${OIDCProvider}"
+                },
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Condition": {
+                  "StringLike": {
+                    "${OIDCProvider}:sub": "system:serviceaccount:worker-*:deployment-runner"
                   }
                 }
-              ]
-            }
+              }
+            ]
+          }
       Path: /
       Policies:
         - PolicyName: !Sub "can-list-objects-in-source-buckets-${Environment}"
@@ -47,26 +46,28 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: 's3:ListBucket'
+                Action: "s3:ListBucket"
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}"
+                  - !Sub "arn:aws:s3:::biomage-uploaded-samples-${Environment}"
         - PolicyName: !Sub "can-download-objects-from-source-buckets-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: 's3:GetObject'
+                Action: "s3:GetObject"
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
+                  - !Sub "arn:aws:s3:::biomage-uploaded-samples-${Environment}/*"
         - PolicyName: !Sub "can-upload-object-to-destination-bucket-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: 's3:PutObject'
+                Action: "s3:PutObject"
                 Resource:
                   - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
         - PolicyName: !Sub "can-read-from-worker-queue-${Environment}"
@@ -75,16 +76,16 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'sqs:ReceiveMessage'
-                  - 'sqs:DeleteMessage'
-                  - 'sqs:GetQueueUrl'
-                Resource: !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:queue-job-*-${Environment}.fifo"      
+                  - "sqs:ReceiveMessage"
+                  - "sqs:DeleteMessage"
+                  - "sqs:GetQueueUrl"
+                Resource: !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:queue-job-*-${Environment}.fifo"
         - PolicyName: !Sub "can-push-to-sns-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: 'sns:Publish'
+                Action: "sns:Publish"
                 Resource: !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:work-results-${Environment}-*"
         - PolicyName: !Sub "can-manage-tables-${Environment}"
           PolicyDocument:

--- a/cf/s3.yaml
+++ b/cf/s3.yaml
@@ -16,7 +16,7 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub "worker-results-${Environment}"
-      PublicAccessBlockConfiguration: 
+      PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         BlockPublicPolicy: True
         IgnorePublicAcls: True
@@ -26,24 +26,35 @@ Resources:
           - Id: DeleteContentAfterTwoDays
             Status: "Enabled"
             ExpirationInDays: 3
-  
+
   # The bucket that contains the count matrix files used for the experiments.
   SourceBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub "biomage-source-${Environment}"
-      PublicAccessBlockConfiguration: 
+      PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
-  
+
   # The bucket that contains the original unfiltered versions of the count matrix files used for the experiments.
   OriginalFilesBucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub "biomage-originals-${Environment}"
-      PublicAccessBlockConfiguration: 
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: True
+
+  # The bucket that contains the original unfiltered versions of the count matrix files used for the experiments.
+  UploadedSamples:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "biomage-uploaded-samples-${Environment}"
+      PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         BlockPublicPolicy: True
         IgnorePublicAcls: True


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-649

#### Link to staging deployment URL 

N.A.

#### Links to any Pull Requests related to this

N.A.

#### Anything else the reviewers should know about the changes here

Created new resources : 
- Cognito identity pool ID
- S3 bucket : `biomage-uploaded-samples`
- Role : `ui-role` with permissions for file uploads
- Added role for worker to get objects from new bucket

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR