### PR TITLE
Add roles to allow plots and tables s3 to be managed by api and pipeline

### DIFF
--- a/cf/irsa-api-role.yaml
+++ b/cf/irsa-api-role.yaml
@@ -83,6 +83,7 @@ Resources:
                 Action: "s3:GetObject"
                 Resource:
                   - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
+                  - !Sub "arn:aws:s3:::plots-tables-${Environment}/*"
         - PolicyName: !Sub "can-access-details-of-redis-cluster-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"

--- a/cf/irsa-pipeline-role.yaml
+++ b/cf/irsa-pipeline-role.yaml
@@ -52,6 +52,7 @@ Resources:
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
                   - !Sub "arn:aws:s3:::worker-results-${Environment}"
+                  - !Sub "arn:aws:s3:::plots-tables-${Environment}"
         - PolicyName: !Sub "can-download-objects-from-source-buckets-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"
@@ -69,6 +70,7 @@ Resources:
                 Action: 's3:PutObject'
                 Resource:
                   - !Sub "arn:aws:s3:::worker-results-${Environment}/*"
+                  - !Sub "arn:aws:s3:::plots-tables-${Environment}/*"
         - PolicyName: !Sub "can-push-to-sns-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-653

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR