### PR TITLE
added permissions to list buckets in S3

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -56,6 +56,15 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:s3:::*-${Environment}/*"
 
+        - PolicyName: !Sub "can-list-${Environment}-s3"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: 's3:ListBucket'
+                Resource:
+                  - !Sub "arn:aws:s3:::*-${Environment}"
+
         - PolicyName: !Sub "can-manage-${Environment}-sns"
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

It looks like the policy can-manage-${Environment}-s3 allows to manage items under the buckets, but not the buckets themselves (notice the different resouces arn:aws:s3:::*-${Environment}/* vs. arn:aws:s3:::*-${Environment}).

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR