### PR TITLE
Wait for the api to be ready before setting up SNS

### DIFF
--- a/.github/workflows/deploy-staging-sns-test.yaml
+++ b/.github/workflows/deploy-staging-sns-test.yaml
@@ -1,0 +1,151 @@
+name: Deploy a staging environment waiting for SNS
+on: 
+  workflow_dispatch:
+    inputs:
+      manifest:
+        description: 'The manifest file to deploy (base64 encoded)'
+        required: true
+      sandbox-id:
+        description: 'The sandbox ID to deploy under'
+        required: true
+      secrets:
+        description: 'Encrypted secrets to use for this task'
+        required: true
+
+jobs:
+  deploy-staging:
+    name: Deploy staging environment
+    runs-on: ubuntu-latest
+    steps:
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+      
+      - id: install-aws-cli
+        name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+      
+      - id: decrypt-secrets
+        name: Decrypt credentials from user.
+        run: |-
+            SECRETS="$(aws kms decrypt \
+              --key-id arn:aws:kms:eu-west-1:242905224710:alias/iac-secret-key \
+              --ciphertext-blob fileb://<(echo $CIPHERTEXT | base64 --decode) \
+              --output text --query Plaintext)"
+            
+            DEPLOYMENT_AWS_ACCESS_KEY_ID="$(echo $SECRETS | base64 --decode | jq -r '.access_key')"
+            DEPLOYMENT_AWS_SECRET_ACCESS_KEY="$(echo $SECRETS | base64 --decode | jq -r '.secret_key')"
+            DEPLOYMENT_GITHUB_API_TOKEN="$(echo $SECRETS | base64 --decode | jq -r '.github_api_token')"
+
+            echo "::add-mask::$SECRETS"
+            
+            echo "::add-mask::$DEPLOYMENT_AWS_ACCESS_KEY_ID"
+            echo "::add-mask::$DEPLOYMENT_AWS_SECRET_ACCESS_KEY"
+            echo "::add-mask::$DEPLOYMENT_GITHUB_API_TOKEN"
+
+            echo "::set-output name=aws-access-key::$DEPLOYMENT_AWS_ACCESS_KEY_ID"
+            echo "::set-output name=aws-secret-access-key::$DEPLOYMENT_AWS_SECRET_ACCESS_KEY"
+            echo "::set-output name=github-api-token::$DEPLOYMENT_GITHUB_API_TOKEN"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          CIPHERTEXT: ${{ github.event.inputs.secrets }}
+
+      - id: setup-aws-submitted
+        name: Configure AWS credentials with submitted details
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ steps.decrypt-secrets.outputs.aws-access-key }}
+          aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
+          aws-region: eu-west-1
+
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+
+      - id: add-manifest-to-repo
+        name: Add manifest file to repository.
+        run: |-
+          echo "$MANIFEST" | base64 -d > ./releases/staging/$SANDBOX_ID.yaml
+        env:
+          MANIFEST: ${{ github.event.inputs.manifest }}
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+
+      - id: set-name
+        name: Set name of the CloudFormation stack for SNS topic
+        run: |-
+          BASE_NAME=biomage-sns-staging-$SANDBOX_ID
+          echo "::set-output name=sns-name::$BASE_NAME"
+
+          BASE_NAME=biomage-cognito-staging-$SANDBOX_ID
+          echo "::set-output name=cognito-name::$BASE_NAME"
+        env:
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+      
+      #- id: deploy-template-cognito
+      #  name: Deploy CloudFormation stack for Cognito pool clients
+      #  uses: aws-actions/aws-cloudformation-github-deploy@v1
+      #  if: ${{ github.ref == 'refs/heads/master' }}
+      #  with:
+      #    parameter-overrides: "Environment=staging,SandboxID=${{ github.event.inputs.sandbox-id }}"
+      #    name: ${{ steps.set-name.outputs.cognito-name }}
+      #    template: cf/userpoolclient.yaml
+      #    no-fail-on-empty-changeset: "1"
+      #    capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+
+      - id: wait-for-api
+        name: Wait for the API to be responsive
+        run: |-
+          URL=https://api-${SANDBOX_ID}.scp-staging.biomage.net/v1/health
+          until curl --fail --silent ${URL}; do
+            printf '.'
+            sleep 5
+          done
+        env:
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+      
+      - id: deploy-template-sns
+        name: Deploy CloudFormation stack for SNS topic
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          parameter-overrides: "Environment=staging,SandboxID=${{ github.event.inputs.sandbox-id }}"
+          name: ${{ steps.set-name.outputs.sns-name }}
+          template: cf/sns.yaml
+          no-fail-on-empty-changeset: "1"
+          capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+
+      - id: disable-admin-enforcement
+        name: Temporarily disable admin enforcement
+        uses: benjefferies/branch-protection-bot@master
+        with:
+          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          owner: biomage-ltd
+          repo: iac
+          enforce_admins: false
+          retries: 8
+
+      - id: push-deployment
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Deploy staging environment ${{ github.event.inputs.sandbox-id }}
+          push_options: --force
+
+      - id: enable-admin-enforcement
+        name: Re-enable admin enforcement
+        uses: benjefferies/branch-protection-bot@master
+        if: always()
+        with:
+          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          owner: biomage-ltd
+          repo: iac
+          enforce_admins: true
+          retries: 8


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-832
#### Link to staging deployment URL 
N/A
#### Links to any Pull Requests related to this
N/A
#### Anything else the reviewers should know about the changes here
Temp action in order to test before submitting a real request to change  `.github/workflows/deploy-staging.yaml`
# Changes
### Code changes
* swap SNS and Cognito pool creation order (and temporarily comment out the later) 
* add a step to wait for the API health endpoint to be responsive before setting up SNS
# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR