### PR TITLE
Update the experiments DynamoDB table in staging and production

### DIFF
--- a/dynamodb-migrations/2021-05-04T12:41:17Z-add-auth-experiment-fields.js
+++ b/dynamodb-migrations/2021-05-04T12:41:17Z-add-auth-experiment-fields.js
@@ -1,0 +1,54 @@
+const Dyno = require('dyno');
+
+let updated = 0;
+
+module.exports = (record, dyno, callback) => {  
+
+  if (!process.env.K8S_ENV) {
+    throw new Error('Environment (staging/production) must be specified.');
+  }
+
+  if (record.rbac_can_write) {
+      console.log(`${record.experimentId} skipped as \`rbac_can_write\` attribute already exists.`)
+      return callback();
+  }
+
+  if (record.project_id) {
+    console.log(`${record.experimentId} skipped as \`project_id\` attribute already exists.`)
+    return callback();
+  }
+
+  console.log(`${record.experimentId} flagged for updates`);
+
+  const attrValues = {
+    ':pid': record.experimentId,
+  };
+
+  if(process.env.K8S_ENV === 'production') {
+    attrValues[':cw'] = Dyno.createSet(['a07c6615-d982-413b-9fdc-48bd85182e83']);
+  } else if(process.env.K8S_ENV === 'staging') {
+    attrValues[':cw'] = Dyno.createSet(['70c213d4-e7b6-4920-aefb-706ce8606ee2']);
+  }
+
+  // If you are running a dry-run, `dyno` will be null
+  if (!dyno) return callback();
+
+  dyno.updateItem({
+    Key: {experimentId: record.experimentId},
+    UpdateExpression: 'SET rbac_can_write = :cw, projectId = :pid',
+    ExpressionAttributeValues: attrValues
+  }, (err) => {
+    if(err) {
+      console.log(`${record.experimentId} failed to update`);
+      throw new Error(err);
+    }
+  });
+
+  updated++;
+  callback();
+}
+
+module.exports.finish = (dyno, callback) => {
+  console.log(`Updated ${updated} records.`);
+  callback();
+}

--- a/dynamodb-migrations/README.md
+++ b/dynamodb-migrations/README.md
@@ -4,6 +4,21 @@ DynamoDB migration scripts
 This directory contains scripts designed to mass-edit experiments, projects, plots,
 and other resources found in DynamoDB to ensure consistent and safe deployments.
 
+Useful information
+------------------
+
+* The workflow below is completely manual. An automatic, CI-based workflow is in the works, so this is a temporary
+solution. Scripts should be submitted as a merge request and inspected before performing the manual workflow below.
+
+* This workflow provides no rollbacks. Make sure you test on a local environment first. You can edit the configuration
+per the `dynamodb-migration` docs to attach this to a custom AWS endpoint like Inframock. See the `README` in the root
+of this repository to see how that is done.
+
+* The dry-run functionality is quite limited. It does not allow you to perform any AWS queries, as the DynamoDB connection
+(named `dyno`) is not passed in for dry runs. You are, however, given each record that will be modified as a JavaScript
+object, which you can use to perform some tests.
+
+
 How to use
 ----------
 
@@ -13,14 +28,15 @@ Name all your migration scripts starting with the ISO date string for the time
 the script was created in UTC. This is so the files is ordered correctly under an
 alphabetical ordering.
 
-You will need to install the tool [dynamodb-migrations](https://www.npmjs.com/package/dynamodb-migrations)
+You will need to install the tool [dynamodb-migrations](https://www.npmjs.com/package/dynamodb-migrations).
+This is a global tool that exposes the `dynamodb-migrate` command.
 
 You will need to link the package `dyno` into the `dynamodb-migrations` folder:
 
     cd dynamodb_migrations/
     npm link dyno
 
-Then, run the following to test the script in dry run:
+Then, run the following to test the script in dry run (no `--live` flag supplied means a dry run is being performed):
 
     K8S_ENV=staging dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno
     K8S_ENV=production dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno
@@ -29,3 +45,4 @@ If it works, you can deploy it by appending the `--live` flag:
 
     K8S_ENV=staging dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno --live
     K8S_ENV=production dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno --live
+

--- a/dynamodb-migrations/README.md
+++ b/dynamodb-migrations/README.md
@@ -1,0 +1,31 @@
+DynamoDB migration scripts
+==========================
+
+This directory contains scripts designed to mass-edit experiments, projects, plots,
+and other resources found in DynamoDB to ensure consistent and safe deployments.
+
+How to use
+----------
+
+*NOTE:* These are temporary instructions until a proper workflow is established.
+
+Name all your migration scripts starting with the ISO date string for the time
+the script was created in UTC. This is so the files is ordered correctly under an
+alphabetical ordering.
+
+You will need to install the tool [dynamodb-migrations](https://www.npmjs.com/package/dynamodb-migrations)
+
+You will need to link the package `dyno` into the `dynamodb-migrations` folder:
+
+    cd dynamodb_migrations/
+    npm link dyno
+
+Then, run the following to test the script in dry run:
+
+    K8S_ENV=staging dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno
+    K8S_ENV=production dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno
+
+If it works, you can deploy it by appending the `--live` flag:
+
+    K8S_ENV=staging dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno --live
+    K8S_ENV=production dynamodb-migrate scan eu-west-1/TABLE_NAME ./dynamodb-migrations/SCRIPT_NAME.js --dyno --live


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-749

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
Overall, the method of deploying these DynamoDB scripts is very janky. I would advise to look for an alternative solution to deploy migration scripts, as using the utility we previously thought was well-designed is actually quite cumbersome and problematic.

# Changes
### Code changes
Added new migration script that adds required `can_read` and `projectId` values to tables.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR