### PR TITLE
Create release action

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -99,8 +99,10 @@ jobs:
             git checkout develop
             git merge --no-edit --no-ff "${RELEASE}"
 
-            # push release commits & tags
-            git push origin ${RELEASE_BRANCH} develop --tags
+            # push release commits
+            git push origin ${RELEASE_BRANCH} develop
+            # push force tag to allow re-releasing 
+            git push origin refs/tags/${RELEASE} --force
         env:
           RELEASE: ${{ github.event.inputs.release }}
           RELEASE_BRANCH: "master"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -90,7 +90,7 @@ jobs:
             echo "==> Creating ${RELASE} from $(git branch --show-current) branch"
             git config --local "gitflow.branch.release/${RELEASE}.base" develop
             git checkout -b "release/${RELEASE}" develop
-
+ 
             git checkout ${RELEASE_BRANCH}
             git merge --no-edit --no-ff "release/${RELEASE}"
             git checkout ${RELEASE_BRANCH}
@@ -103,7 +103,7 @@ jobs:
             git push origin ${RELEASE_BRANCH} develop --tags
         env:
           RELEASE: ${{ github.event.inputs.release }}
-          RELEASE_BRANCH: "master-test"
+          RELEASE_BRANCH: "master"
           REPO: ${{ github.event.inputs.repo }}
       
       - id: enable-admin-enforcement

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -78,8 +78,7 @@ jobs:
 
             # We check for differences because ${RELEASE_BRANCH} and develop are in different commits (due to merge) so git log is never empty.
             if [ "$(git diff ${RELEASE_BRANCH}..develop)" = "" ]; then
-              echo " * No changes detected between ${RELEASE_BRANCH} and develop, skipping ${REPO} release."
-              exit 0
+              echo " * No changes detected between ${RELEASE_BRANCH} and develop."
             else
               echo " * Found changes between ${RELEASE_BRANCH} and develop. Commits found: "
               echo "$(git log --pretty=format:%s ${RELEASE_BRANCH}..develop | xargs -I % sh -c 'echo "\t- %";' )"
@@ -88,7 +87,7 @@ jobs:
 
             git config user.name "Github Actions"
 
-            echo "==> Creatinggithub.events.inputs.release${RELASE} from $(git branch --show-current) branch"
+            echo "==> Creating ${RELASE} from $(git branch --show-current) branch"
             git config --local "gitflow.branch.release/${RELEASE}.base" develop
             git checkout -b "release/${RELEASE}" develop
 


### PR DESCRIPTION
Release tags are now pushed independently and with `--force` to allow re-releasing a tag without conflict failure.