### PR TITLE
remove dynamo retain policies

### DIFF
--- a/cf/dynamo.yaml
+++ b/cf/dynamo.yaml
@@ -14,8 +14,6 @@ Parameters:
 Resources:
   ExperimentTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub "experiments-${Environment}"
       AttributeDefinitions:
@@ -27,8 +25,6 @@ Resources:
       BillingMode: "PAY_PER_REQUEST"
   PlotsTablesTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub "plots-tables-${Environment}"
       AttributeDefinitions:
@@ -44,8 +40,6 @@ Resources:
       BillingMode: "PAY_PER_REQUEST"
   SamplesTable:
     Type: AWS::DynamoDB::Table
-    DeletionPolicy: Retain
-    UpdateReplacePolicy: Retain
     Properties:
       TableName: !Sub "samples-${Environment}"
       AttributeDefinitions:

--- a/cf/irsa-api-role.yaml
+++ b/cf/irsa-api-role.yaml
@@ -76,7 +76,6 @@ Resources:
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/experiments-${Environment}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/plots-tables-${Environment}"
                   - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/samples-${Environment}"
-                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/projects-${Environment}"
         - PolicyName: !Sub "can-download-objects-from-s3-buckets-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

- Remove `retain` policies so that IAC can effect changes
- Remove API role to project to reflect IAC.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR