### PR TITLE
fix incorrect etag casing

### DIFF
--- a/cf/s3.yaml
+++ b/cf/s3.yaml
@@ -101,7 +101,7 @@ Resources:
           - AllowedHeaders:
               - '*'
             ExposedHeaders:
-              - Etag
+              - ETag
               - "x-amz-server-side-encryption"
               - "x-amz-request-id"
               - "x-amz-id-2"


### PR DESCRIPTION
# Background
#### Link to issue 

https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1623850681027300

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

- Change `Etag` to `ETag`

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR