### PR TITLE
return cognito settings before changes to userpool

### DIFF
--- a/cf/cognito.yaml
+++ b/cf/cognito.yaml
@@ -161,7 +161,7 @@ Resources:
         SnsCallerArn: !GetAtt SMSRole.Arn
       MfaConfiguration: "OPTIONAL"
       Schema:
-        - Name: Full name
+        - Name: name
           AttributeDataType: String
           Mutable: true
           Required: true
@@ -172,7 +172,7 @@ Resources:
         - Name: institution
           AttributeDataType: String
           Mutable: true
-          Required: true
+          Required: false
       SmsAuthenticationMessage: 'Your authentication code for Cellscope by Biomage is {####}.'
       SmsVerificationMessage: 'Your verification code for Cellscope by Biomage is {####}.'
       UsernameAttributes:


### PR DESCRIPTION
# Background
#### Link to issue 

Cognito attributes can not be changed once they are set. PR #143 tried to change this, which causes errors when trying to update cognito schema as seen below : 

![image](https://user-images.githubusercontent.com/2862362/127453426-9cbeb6df-9ae7-4aa4-8335-7a0dbcf03eb2.png)

This PR rollsback the changes so that the desired update to `UIRole` can be made.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR