### PR TITLE
added permissions for new pipeline scaling work

### DIFF
--- a/cf/irsa-api-role.yaml
+++ b/cf/irsa-api-role.yaml
@@ -121,7 +121,7 @@ Resources:
                 Action: "eks:DescribeCluster"
                 Resource:
                   - !Sub "arn:aws:eks:${AWS::Region}:${AWS::AccountId}:cluster/biomage-${Environment}"
-        - PolicyName: !Sub "can-manage-state-machine-${Environment}" #  this should be deprecated once production env. uses new qc & gem2s state machines
+        - PolicyName: !Sub "can-manage-state-machine-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -133,7 +133,8 @@ Resources:
                   - "states:StartExecution"
                   - "states:TagResource"
                 Resource:
-                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:biomage-pipeline-${Environment}-*"  #  this should be deprecated once production env. uses new qc & gem2s state machines
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:biomage-pipeline-${Environment}-*"  # used to access old pipeline executions
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:pipeline-${Environment}-*"
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:biomage-qc-${Environment}-*"
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:biomage-gem2s-${Environment}-*"
         - PolicyName: !Sub "can-stop-execution-${Environment}"
@@ -146,7 +147,8 @@ Resources:
                   - "states:StopExecution"
                   - "states:GetExecutionHistory"
                 Resource:
-                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:biomage-pipeline-${Environment}-*:*" #  this should be deprecated once production env. uses new qc & gem2s state machines
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:biomage-pipeline-${Environment}-*:*" # used to access old pipeline executions
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:pipeline-${Environment}-*:*"
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:biomage-qc-${Environment}-*:*"
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:execution:biomage-gem2s-${Environment}-*:*"
         - PolicyName: !Sub "can-create-activity-${Environment}"
@@ -159,6 +161,7 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:biomage-qc-${Environment}-*"
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:biomage-gem2s-${Environment}-*"
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:pipeline-${Environment}-*"
         - PolicyName: !Sub "can-pass-state-machine-executionrole-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
Added new permissions for the API to create activities (pipelines). The names are `pipeline-${Environment}-*:*"` instead of the previous `biomage-pipeline-${Environment}-*:*"` because those activity ARNs are too long (over 63 chars) and could not be set as a pod label in kubernetes. 