### PR TITLE
added missing permissions for pipeline role to retrieve activity

### DIFF
--- a/cf/irsa-pipeline-role.yaml
+++ b/cf/irsa-pipeline-role.yaml
@@ -96,3 +96,4 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:biomage-qc-${Environment}-*"
                   - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:biomage-gem2s-${Environment}-*"
+                  - !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:pipeline-${Environment}-*"


### PR DESCRIPTION
Added missing permissions for new pipelines for the scaling work called 'pipeline-*' (removed biomage because the name was too long for kubernetes metadata which needs to be under 54 chars.