### PR TITLE
Add PutObject permission for biomage-originals

### DIFF
--- a/cf/irsa-api-role.yaml
+++ b/cf/irsa-api-role.yaml
@@ -97,6 +97,7 @@ Resources:
                 Action: "s3:PutObject"
                 Resource:
                   - !Sub "arn:aws:s3:::cell-sets-${Environment}/*"
+                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
         - PolicyName: !Sub "can-delete-original-files-s3-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1307

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
The api needs permissions to put object so that the presigned url it generates can be used for this purpose

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR