### PR TITLE
creating fargate profile first thing in the deployment

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -71,6 +71,38 @@ jobs:
         with:
           token: ${{ secrets.API_TOKEN_GITHUB }}
 
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
+
+      - id: create-worker-fargate-profile
+        name: Attempt to create worker Fargate profile
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 300
+          max_attempts: 5
+          retry_on: error
+          command: eksctl create fargateprofile --cluster biomage-staging --name worker-${SANDBOX_ID} --namespace worker-${SANDBOX_ID}
+          # Add jitter to break up correlated events.
+          on_retry_command: sleep $((20 + RANDOM % 10));
+        env:
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+
+      - id: create-pipeline-fargate-profile
+        name: Attempt to create pipeline Fargate profile
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 300
+          max_attempts: 5
+          retry_on: error
+          command: eksctl create fargateprofile --cluster biomage-staging --name pipeline-${SANDBOX_ID} --namespace pipeline-${SANDBOX_ID}
+          # Add jitter to break up correlated events.
+          on_retry_command: sleep $((20 + RANDOM % 10))
+        env:
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+
       - id: add-manifest-to-repo
         name: Add manifest file to repository.
         run: |-
@@ -152,34 +184,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
-      - id: install-eksctl
-        name: Install eksctl
-        run: |-
-          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-          sudo mv /tmp/eksctl /usr/local/bin
-
-      - id: create-worker-fargate-profile
-        name: Attempt to create worker Fargate profile
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 300
-          max_attempts: 5
-          retry_on: error
-          command: eksctl create fargateprofile --cluster biomage-staging --name worker-${{ github.event.inputs.sandbox-id }} --namespace worker-${{ github.event.inputs.sandbox-id }} | grep "created Fargate profile"
-          # Add jitter to break up correlated events.
-          on_retry_command: sleep $((20 + RANDOM % 10));
-
-      - id: create-pipeline-fargate-profile
-        name: Attempt to create pipeline Fargate profile
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 300
-          max_attempts: 5
-          retry_on: error
-          command: eksctl create fargateprofile --cluster biomage-staging --name pipeline-${{ github.event.inputs.sandbox-id }} --namespace pipeline-${{ github.event.inputs.sandbox-id }} | grep "created Fargate profile"
-          # Add jitter to break up correlated events.
-          on_retry_command: sleep $((20 + RANDOM % 10))
-
       - id: enable-admin-enforcement
         name: Re-enable admin enforcement
         uses: benjefferies/branch-protection-bot@master
@@ -190,3 +194,12 @@ jobs:
           repo: iac
           enforce_admins: true
           retries: 8
+
+     - id: cleanup-fargate-if-failure
+       name: Remove fargate profiles if the staging failed
+       if: ${{ failure() }}
+        run: |-
+          eksctl delete fargateprofile --cluster biomage-staging --name pipeline-${SANDBOX_ID} || echo "unsuccessful delete"
+          eksctl delete fargateprofile --cluster biomage-staging --name worker-${SANDBOX_ID} || echo "unsuccessful delete"
+        env:
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}


### PR DESCRIPTION
Installing fargate before the actual deployment to avoid pods being tried to create in the node (which are not deleted once fargate is deployed).