### PR TITLE
Add fargate profile automatically on infrastructure creation

### DIFF
--- a/infra/cluster.yaml
+++ b/infra/cluster.yaml
@@ -35,3 +35,11 @@ nodeGroups:
       withAddonPolicies:
         ebs: true
         autoScaler: true
+
+fargateProfiles:
+  - name: worker-default
+    selectors:
+      - namespace: worker-default
+  - name: pipeline-default
+    selectors:
+      - namespace: pipeline-default


### PR DESCRIPTION
This adds the default fargate profiles for both staging and production environments.