### PR TITLE
[BIOMAGE-1427] Fix the config difference for staging and production services

### DIFF
--- a/charts/nodejs/templates/_helpers.tpl
+++ b/charts/nodejs/templates/_helpers.tpl
@@ -7,11 +7,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "appname" -}}
-{{- if (eq .Values.kubernetes.env "production") -}}
-{{- printf "%s" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
 {{- printf "%s-%s" .Release.Name .Values.biomageCi.sandboxId | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 
 {{- define "hostname" -}}


### PR DESCRIPTION
This PR uniformly assigns the same `appname` template parameter to all environments.

After investigation, I have found that we do not rely on this value being different in production vs staging in any part of the code, and therefore it is safe to change it.

However, as part of this ticket, there are other changes, including updating the pipeline to remove the fix implemented in https://github.com/biomage-ltd/pipeline/pull/158 and pushing that version to production before updating the configuration to make sure there is no downtime to production.