### PR TITLE
fix access_token

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -24,7 +24,7 @@ jobs:
         name: Temporarily disable admin enforcement
         uses: benjefferies/branch-protection-bot@master
         with:
-          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
           owner: biomage-ltd
           repo: ${{ github.event.inputs.repo }}
           enforce_admins: false
@@ -68,7 +68,7 @@ jobs:
         uses: benjefferies/branch-protection-bot@master
         if: always()
         with:
-          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
           owner: biomage-ltd
           repo: ${{ github.event.inputs.repo }}
           enforce_admins: true

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -162,7 +162,7 @@ jobs:
         name: Temporarily disable admin enforcement
         uses: benjefferies/branch-protection-bot@master
         with:
-          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
           owner: biomage-ltd
           repo: iac
           enforce_admins: false
@@ -195,7 +195,7 @@ jobs:
         uses: benjefferies/branch-protection-bot@master
         if: always()
         with:
-          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
           owner: biomage-ltd
           repo: iac
           enforce_admins: true

--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -157,7 +157,7 @@ jobs:
         name: Temporarily disable admin enforcement
         uses: benjefferies/branch-protection-bot@master
         with:
-          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
           owner: biomage-ltd
           repo: iac
           enforce_admins: false
@@ -190,7 +190,7 @@ jobs:
         uses: benjefferies/branch-protection-bot@master
         if: always()
         with:
-          access-token: ${{ secrets.API_TOKEN_GITHUB }}
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
           owner: biomage-ltd
           repo: iac
           enforce_admins: true


### PR DESCRIPTION
# Background
#### Link to issue 

https://github.com/benjefferies/branch-protection-bot updates `access-token` to `access_token`, causing our CI to break : https://github.com/benjefferies/branch-protection-bot/commit/2b60c2b3e633837b8967f4e8426cc8c71782d6ad

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR