### PR TITLE
[BIOMAGE-1494] - Migration to add prefiltered attribute

### DIFF
--- a/migrations/dynamodb-migrations/2021-10-07T15:51:00Z-add-classifier-prefiltered.js
+++ b/migrations/dynamodb-migrations/2021-10-07T15:51:00Z-add-classifier-prefiltered.js
@@ -1,0 +1,51 @@
+const Dyno = require('dyno');
+
+let updated = 0;
+
+module.exports = (record, dyno, callback) => {  
+
+  if (!process.env.K8S_ENV) {
+    throw new Error('Environment (staging/production) must be specified.');
+  }
+
+  if(!record.processingConfig?.classifier) {
+    console.log(`${record.experimentId} skipped as it does not contain classifier in processingConfig`)
+    return callback();
+  }
+
+
+  if(!Object.prototype.hasOwnProperty.call(record.processingConfig?.classifier, 'enabled')) {
+    console.log(`${record.experimentId} skipped as it does not contain the right processingConfig schema`)
+    return callback();
+  }
+
+  const enabled = record.processingConfig.classifier.enabled
+
+  console.log(`${record.experimentId} flagged for updates with prefiltered value ${!enabled}`);
+
+  const attrValues = {
+    ':prefiltered': !enabled,
+  };
+
+  // If you are running a dry-run, `dyno` will be null
+  if (!dyno) return callback();
+
+  dyno.updateItem({
+    Key: {experimentId: record.experimentId},
+    UpdateExpression: 'SET processingConfig.classifier.prefiltered = :prefiltered',
+    ExpressionAttributeValues: attrValues
+  }, (err) => {
+    if(err) {
+      console.log(`${record.experimentId} failed to update`);
+      throw new Error(err);
+    }
+  });
+
+  updated++;
+  callback();
+}
+
+module.exports.finish = (dyno, callback) => {
+  console.log(`Updated ${updated} records.`);
+  callback();
+}


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1494

#### Link to staging deployment URL 

In UI PR

#### Links to any Pull Requests related to this

UI - https://github.com/biomage-ltd/ui/pull/528
API - https://github.com/biomage-ltd/api/pull/242
Pipeline - https://github.com/biomage-ltd/pipeline/pull/178
IAC Migration - https://github.com/biomage-ltd/iac/pull/191

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR