### PR TITLE
hotfix: Extend timeout period for readiness probes

### DIFF
--- a/charts/nodejs/values.yaml
+++ b/charts/nodejs/values.yaml
@@ -51,8 +51,8 @@ livenessProbe:
 
 readinessProbe:
   path: "/"
-  initialDelaySeconds: 5
-  timeoutSeconds: 3
+  initialDelaySeconds: 15
+  timeoutSeconds: 10
   scheme: "HTTP"
   probeType: "httpGet"
 


### PR DESCRIPTION
# Background
#### Link to issue
See Slack at https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1634118672008200

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
This will automatically apply to all environments, including production.

# Changes
### Code changes
Extended the timeout period of the Kubernetes readiness probes to 10 seconds. This should get rid of issues around sporadic gateway errors reported by our canaries.
