### PR TITLE
[BIOMAGE-1495] Scale down Redis instances

### DIFF
--- a/cf/redis.yaml
+++ b/cf/redis.yaml
@@ -42,7 +42,7 @@ Resources:
     Properties:
       ReplicationGroupId: !Sub "biomage-redis-${Environment}"
       ReplicationGroupDescription: !Sub "Biomage ElastiCache cluster for environment ${Environment}"
-      CacheNodeType: !If [isProd, "cache.m4.xlarge", "cache.m4.xlarge"]
+      CacheNodeType: !If [isProd, "cache.t3.medium", "cache.t3.medium"]
       CacheSubnetGroupName: !Ref CacheSubnetGroup
       Engine: redis
       NumCacheClusters: 2

--- a/cf/redis.yaml
+++ b/cf/redis.yaml
@@ -42,7 +42,7 @@ Resources:
     Properties:
       ReplicationGroupId: !Sub "biomage-redis-${Environment}"
       ReplicationGroupDescription: !Sub "Biomage ElastiCache cluster for environment ${Environment}"
-      CacheNodeType: !If [isProd, "cache.t3.medium", "cache.t3.medium"]
+      CacheNodeType: "cache.t3.medium"
       CacheSubnetGroupName: !Ref CacheSubnetGroup
       Engine: redis
       NumCacheClusters: 2

--- a/cf/redis.yaml
+++ b/cf/redis.yaml
@@ -14,9 +14,6 @@ Parameters:
     Default: '6379'
     Type: String
 
-Conditions:
-  isProd: !Equals [!Ref Environment, "production"]
-
 Outputs:
   ElastiCachePrimaryEndpointAddress:
     Description: Address to use to connect to Primary Cluster endpoint


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-1495

#### Link to staging deployment URL
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
Pricing and node type available at https://aws.amazon.com/elasticache/pricing/

# Changes
### Code changes
Scale down current Redis database instance to a smaller value now that caching results is not done through Redis.
