### PR TITLE
Increase replica count of api/ui to 4

### DIFF
--- a/charts/nodejs/values.yaml
+++ b/charts/nodejs/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+replicaCount: 4
 strategyType:
 deploymentApiVersion: apps/v1
 


### PR DESCRIPTION
API and UI only spin up one instance at a time. This is a major issue now with more users and causes outages. This PR adds four replicas to each so we maintain availability even under larger loads.