### PR TITLE
moved event exporter to api charts

### DIFF
--- a/charts/nodejs/templates/delete-pods-right-to-api.yaml
+++ b/charts/nodejs/templates/delete-pods-right-to-api.yaml
@@ -1,26 +1,20 @@
 {{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "cluster-ee") }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: can-delete-pods
-  namespace: {{ .Release.Namespace }}
-  labels:
-    sandboxId: "{{ .Values.sandboxId }}"
 rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: api-can-delete-pods
-  namespace: {{.Release.Namespace}}
-  labels:
-    sandboxId: "{{ .Values.sandboxId }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: can-delete-pods
 subjects:
 - kind: ServiceAccount

--- a/charts/nodejs/templates/delete-pods-right-to-api.yaml
+++ b/charts/nodejs/templates/delete-pods-right-to-api.yaml
@@ -1,0 +1,29 @@
+{{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "cluster-ee") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: can-delete-pods
+  namespace: {{ .Release.Namespace }}
+  labels:
+    sandboxId: "{{ .Values.sandboxId }}"
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: api-can-delete-pods
+  namespace: {{.Release.Namespace}}
+  labels:
+    sandboxId: "{{ .Values.sandboxId }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: can-delete-pods
+subjects:
+- kind: ServiceAccount
+  name: deployment-runner
+  namespace: {{ .Release.Namespace}}
+{{ end }}

--- a/charts/nodejs/templates/delete-pods-right-to-api.yaml
+++ b/charts/nodejs/templates/delete-pods-right-to-api.yaml
@@ -1,4 +1,4 @@
-{{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "cluster-ee") }}
+{{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "default") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/nodejs/templates/kubernetes-event-exporter.yaml
+++ b/charts/nodejs/templates/kubernetes-event-exporter.yaml
@@ -9,12 +9,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: monitoring
-  name: event-exporter-trial
+  name: event-exporter
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: event-exporter-trial
+  name: event-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -22,7 +22,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     namespace: monitoring
-    name: event-exporter-trial
+    name: event-exporter
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -48,19 +48,19 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: event-exporter-trial
+  name: event-exporter
   namespace: monitoring
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: event-exporter-trial
+        app: event-exporter
         version: v1
     spec:
-      serviceAccountName: event-exporter-trial
+      serviceAccountName: event-exporter
       containers:
-        - name: event-exporter-trial
+        - name: event-exporter
           image: ghcr.io/opsgenie/kubernetes-event-exporter:v0.10
           imagePullPolicy: IfNotPresent
           args:
@@ -74,6 +74,6 @@ spec:
             name: event-exporter-cfg
   selector:
     matchLabels:
-      app: event-exporter-trial
+      app: event-exporter
       version: v1
 {{ end }}

--- a/charts/nodejs/templates/kubernetes-event-exporter.yaml
+++ b/charts/nodejs/templates/kubernetes-event-exporter.yaml
@@ -9,12 +9,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: monitoring
-  name: event-exporter
+  name: event-exporter-trial
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: event-exporter
+  name: event-exporter-trial
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -22,7 +22,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     namespace: monitoring
-    name: event-exporter
+    name: event-exporter-trial
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -48,19 +48,19 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: event-exporter
+  name: event-exporter-trial
   namespace: monitoring
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: event-exporter
+        app: event-exporter-trial
         version: v1
     spec:
-      serviceAccountName: event-exporter
+      serviceAccountName: event-exporter-trial
       containers:
-        - name: event-exporter
+        - name: event-exporter-trial
           image: ghcr.io/opsgenie/kubernetes-event-exporter:v0.10
           imagePullPolicy: IfNotPresent
           args:
@@ -74,6 +74,6 @@ spec:
             name: event-exporter-cfg
   selector:
     matchLabels:
-      app: event-exporter
+      app: event-exporter-trial
       version: v1
 {{ end }}

--- a/charts/nodejs/templates/kubernetes-event-exporter.yaml
+++ b/charts/nodejs/templates/kubernetes-event-exporter.yaml
@@ -1,0 +1,79 @@
+# the event export should be deployed only once per cluster, ie. as part of the default sandbox of the api repo
+{{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "cluster-ee") }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: monitoring
+  name: event-exporter
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: event-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    namespace: monitoring
+    name: event-exporter
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: event-exporter-cfg
+  namespace: monitoring
+data:
+  config.yaml: |
+    logLevel: info
+    logFormat: json
+    route:
+      routes:
+        - match:
+          - kind: "Pod"
+            receiver: "cleanup"
+    receivers:
+      - name: "cleanup"
+        webhook:
+          endpoint: "https://api-{{ .Values.biomageCi.sandboxId }}.scp-staging.biomage.net/v1/kubernetesEvents"
+          headers:
+            User-Agent: kube-event-exporter 1.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: event-exporter
+  namespace: monitoring
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: event-exporter
+        version: v1
+    spec:
+      serviceAccountName: event-exporter
+      containers:
+        - name: event-exporter
+          image: ghcr.io/opsgenie/kubernetes-event-exporter:v0.10
+          imagePullPolicy: IfNotPresent
+          args:
+            - -conf=/data/config.yaml
+          volumeMounts:
+            - mountPath: /data
+              name: cfg
+      volumes:
+        - name: cfg
+          configMap:
+            name: event-exporter-cfg
+  selector:
+    matchLabels:
+      app: event-exporter
+      version: v1
+{{ end }}

--- a/charts/nodejs/templates/kubernetes-event-exporter.yaml
+++ b/charts/nodejs/templates/kubernetes-event-exporter.yaml
@@ -1,5 +1,5 @@
 # the event export should be deployed only once per cluster, ie. as part of the default sandbox of the api repo
-{{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "cluster-ee") }}
+{{ if and (eq .Values.biomageCi.repo "biomage-ltd/api") (eq .Values.biomageCi.sandboxId "default") }}
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1550

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

https://github.com/biomage-ltd/pipeline/pull/186
https://github.com/biomage-ltd/worker/pull/212
https://github.com/biomage-ltd/iac/pull/202

#### Anything else the reviewers should know about the changes here

Removed worker & pipeline cleanup operators because it will because crashed pods will be handled by the API.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
