### PR TITLE
added action to auto-deploy infra users changes

### DIFF
--- a/.github/workflows/backup-dynamodb-tables.yaml
+++ b/.github/workflows/backup-dynamodb-tables.yaml
@@ -1,14 +1,16 @@
 name: Create backup of dynamodb tables
-on: 
+on:
   workflow_dispatch:
     inputs:
       tables:
         description: 'Space separated ids of tables to backup, all if not specified'
         required: false
         default: 'all'
+env:
+  region: 'eu-west-1'
 
 jobs:
-  backup-tables: 
+  backup-tables:
     name: Create backup of dynamodb tables
     runs-on: ubuntu-20.04
     env:
@@ -20,8 +22,8 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-          
+          aws-region: ${{ env.region }}
+
       - id: backup-tables
         name: Create backup of dynamodb tables
         run: |-

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -12,6 +12,8 @@ on:
     paths:
       - 'cf/**.yaml'
       - 'cf/**.yml'
+env:
+  region: 'eu-west-1'
 
 jobs:
   get-modified-templates:
@@ -26,7 +28,7 @@ jobs:
         uses: lots0logs/gh-action-get-changed-files@2.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - id: check-number-of-cf-files
         name: Check CloudFormation templates
         run: |-
@@ -72,7 +74,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       # This is only necessary for IAM Service Account roles.
       - id: get-oidc
@@ -90,7 +92,7 @@ jobs:
           echo "::set-output name=stack-name::$BASE_NAME"
         env:
           FILE_NAME: ${{ matrix.template }}
-      
+
       - id: deploy-template
         name: Deploy CloudFormation template
         if: ${{ !contains(matrix.template, 'irsa-') && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/deploy-changed-users.yaml
+++ b/.github/workflows/deploy-changed-users.yaml
@@ -9,15 +9,6 @@ on:
       - 'infra/biomage-read-only-group/**'
       - 'infra/botkube-configmap.yaml'
       - 'infra/cf-state-machine-role.yaml'
-  pull_request:
-    branches:
-      - master
-    paths:
-      - 'infra/cluster_admins_*'
-      - 'infra/cluster_users'
-      - 'infra/biomage-read-only-group/**'
-      - 'infra/botkube-configmap.yaml'
-      - 'infra/cf-state-machine-role.yaml'
 env:
   region: 'eu-west-1'
 

--- a/.github/workflows/deploy-changed-users.yaml
+++ b/.github/workflows/deploy-changed-users.yaml
@@ -1,0 +1,186 @@
+name: Update infrastructure users on AWS
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'infra/cluster_admins_*'
+      - 'infra/cluster_users'
+      - 'infra/biomage-read-only-group/**'
+      - 'infra/botkube-configmap.yaml'
+      - 'infra/cf-state-machine-role.yaml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'infra/cluster_admins_*'
+      - 'infra/cluster_users'
+      - 'infra/biomage-read-only-group/**'
+      - 'infra/botkube-configmap.yaml'
+      - 'infra/cf-state-machine-role.yaml'
+env:
+  region: 'eu-west-1'
+
+
+jobs:
+  check-secrets:
+    name: Check if secrets are defined
+    runs-on: ubuntu-20.04
+    steps:
+      - id: check-secrets
+        name: Check if necessary secrets are installed.
+        run: |-
+          echo Checking if secrets are defined in the repository.
+
+          if [ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ]
+          then
+            echo AWS Access Key ID not defined.
+            ERROR=true
+          fi
+
+          if [ -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]
+          then
+            echo AWS Access Key ID not defined.
+            ERROR=true
+          fi
+
+          if [ -z "${{ secrets.API_TOKEN_GITHUB }}" ]
+          then
+            echo GitHub deploy key access token not defined.
+            ERROR=true
+          fi
+
+          if [ ! -z "$ERROR" ]
+          then
+            echo
+            echo Make sure you launch this job using the biomage devops tools, and not from GitHub.
+            echo Launching from GitHub directly is not supported to ensure cluster credentials are not
+            echo kept in the repository.
+            false
+          fi
+
+  update-users:
+    name: Updates Kubernetes user-related resources on the EKS cluster
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        environment: ['production', 'staging']
+    env:
+      CLUSTER_ENV: ${{ matrix.environment }}
+      API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+    steps:
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+
+      - id: setup-aws
+        name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.region }}
+
+      - id: add-kubeconfig
+        name: Add k8s config file for existing cluster.
+        run: |-
+          aws eks update-kubeconfig --name biomage-$CLUSTER_ENV
+
+      - id: install-helm
+        name: Install Helm
+        run: |-
+          sudo snap install helm --classic
+
+      - id: install-eksctl
+        name: Install eksctl
+        run: |-
+          curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+          sudo mv /tmp/eksctl /usr/local/bin
+
+      - id: create-botube-namespace
+        name: Attempt to create botkube namespace
+        continue-on-error: true
+        run: |-
+          kubectl create namespace botkube
+
+      - id: deploy-botkube
+        name: Deploy botkube
+        run: |-
+          helm repo add infracloudio https://infracloudio.github.io/charts
+          helm repo update
+
+          helm upgrade --version v0.11.0 botkube --namespace botkube \
+            -f infra/botkube-configmap.yaml \
+            --set communications.slack.token=${{ secrets.BOTKUBE_ACCESS_TOKEN }} \
+            --set config.settings.clustername=$CLUSTER_ENV \
+            infracloudio/botkube \
+            --install --wait
+
+      - id: deploy-read-only-group
+        name: Deploy read-only permission definition for cluster
+        run: |-
+          helm upgrade "biomage-read-only-group" infra/biomage-read-only-group \
+            --install --wait
+
+      - id: deploy-state-machine-role
+        name: Deploy AWS Step Function (state machine) roles
+        uses: aws-actions/aws-cloudformation-github-deploy@v1
+        with:
+          parameter-overrides: "Environment=${{ matrix.environment }}"
+          name: "biomage-state-machine-role-${{ matrix.environment }}"
+          template: 'infra/cf-state-machine-role.yaml'
+          capabilities: 'CAPABILITY_IAM,CAPABILITY_NAMED_IAM'
+          no-fail-on-empty-changeset: "1"
+
+      - id: remove-identitymappings
+        name: Remove all previous identity mappings for IAM users
+        run: |-
+          eksctl get iamidentitymapping --cluster=biomage-$CLUSTER_ENV --output=json | \
+          jq -r '.[] | select(.userarn != null) | .userarn' > /tmp/users_to_remove
+
+          while IFS= read -r user
+          do
+            echo "Remove rights of $user"
+            eksctl delete iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn $user \
+              --all
+          done < "/tmp/users_to_remove"
+
+      # see https://eksctl.io/usage/iam-identity-mappings/
+      - id: add-state-machine-role
+        name: Grant rights to the state machine IAM role.
+        run: |-
+          eksctl create iamidentitymapping \
+            --cluster=biomage-$CLUSTER_ENV \
+            --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/state-machine-role-$CLUSTER_ENV \
+            --group state-machine-runner-group \
+            --username state-machine-runner
+
+      # see https://eksctl.io/usage/iam-identity-mappings/
+      - id: update-identitymapping-admin
+        name: Add cluster admin rights to everyone on the admin list.
+        run: |-
+          while IFS= read -r user
+          do
+            echo "Adding cluster admin rights to $user"
+            eksctl create iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
+              --group system:masters \
+              --username $user
+          done < "infra/cluster_admins_$CLUSTER_ENV"
+
+      # see https://eksctl.io/usage/iam-identity-mappings/
+      - id: update-identitymapping
+        name: Add cluster read-only rights to everyone on the user list.
+        run: |-
+          while IFS= read -r user
+          do
+            echo "Adding cluster read-only rights to $user"
+            eksctl create iamidentitymapping \
+              --cluster=biomage-$CLUSTER_ENV \
+              --arn arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:user/$user \
+              --group read-only \
+              --username $user
+          done < "infra/cluster_users"

--- a/.github/workflows/deploy-changed-users.yaml
+++ b/.github/workflows/deploy-changed-users.yaml
@@ -97,25 +97,6 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
-      - id: create-botube-namespace
-        name: Attempt to create botkube namespace
-        continue-on-error: true
-        run: |-
-          kubectl create namespace botkube
-
-      - id: deploy-botkube
-        name: Deploy botkube
-        run: |-
-          helm repo add infracloudio https://infracloudio.github.io/charts
-          helm repo update
-
-          helm upgrade --version v0.11.0 botkube --namespace botkube \
-            -f infra/botkube-configmap.yaml \
-            --set communications.slack.token=${{ secrets.BOTKUBE_ACCESS_TOKEN }} \
-            --set config.settings.clustername=$CLUSTER_ENV \
-            infracloudio/botkube \
-            --install --wait
-
       - id: deploy-read-only-group
         name: Deploy read-only permission definition for cluster
         run: |-

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -11,6 +11,8 @@ on:
       secrets:
         description: 'Encrypted secrets to use for this task'
         required: true
+env:
+  region: 'eu-west-1'
 
 jobs:
   deploy-staging:
@@ -23,7 +25,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       - id: install-aws-cli
         name: Install AWS CLI
@@ -35,7 +37,7 @@ jobs:
         name: Decrypt credentials from user.
         run: |-
             SECRETS="$(aws kms decrypt \
-              --key-id arn:aws:kms:eu-west-1:242905224710:alias/iac-secret-key \
+              --key-id arn:aws:kms:${REGION}:242905224710:alias/iac-secret-key \
               --ciphertext-blob fileb://<(echo $CIPHERTEXT | base64 --decode) \
               --output text --query Plaintext)"
 
@@ -56,6 +58,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CIPHERTEXT: ${{ github.event.inputs.secrets }}
+          REGION: ${{ env.region }}
 
       - id: setup-aws-submitted
         name: Configure AWS credentials with submitted details
@@ -63,7 +66,7 @@ jobs:
         with:
           aws-access-key-id: ${{ steps.decrypt-secrets.outputs.aws-access-key }}
           aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       - id: checkout
         name: Check out source code
@@ -77,7 +80,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       - id: install-eksctl
         name: Install eksctl

--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       - id: install-aws-cli
         name: Install AWS CLI
@@ -32,7 +32,7 @@ jobs:
         name: Decrypt credentials from user.
         run: |-
             SECRETS="$(aws kms decrypt \
-              --key-id arn:aws:kms:eu-west-1:242905224710:alias/iac-secret-key \
+              --key-id arn:aws:kms:${REGION}:242905224710:alias/iac-secret-key \
               --ciphertext-blob fileb://<(echo $CIPHERTEXT | base64 --decode) \
               --output text --query Plaintext)"
 
@@ -53,6 +53,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CIPHERTEXT: ${{ github.event.inputs.secrets }}
+          REGION: ${{ env.region }}
 
       - id: setup-aws-submitted
         name: Configure AWS credentials with submitted details
@@ -60,7 +61,7 @@ jobs:
         with:
           aws-access-key-id: ${{ steps.decrypt-secrets.outputs.aws-access-key }}
           aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       - id: checkout
         name: Check out source code
@@ -74,7 +75,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
+          aws-region: ${{ env.region }}
 
       - id: install-eksctl
         name: Install eksctl

--- a/.github/workflows/restore-dynamodb-tables.yaml
+++ b/.github/workflows/restore-dynamodb-tables.yaml
@@ -1,14 +1,16 @@
 name: Restore to latest backup for dynamodb tables
-on: 
+on:
   workflow_dispatch:
     inputs:
       tables:
         description: 'Space separated ids of tables to restore backup for, just write all to back up all tables'
         required: false
         default: ''
+env:
+  region: 'eu-west-1'
 
 jobs:
-  restore-tables-backups: 
+  restore-tables-backups:
     name: Restore to latest backup for dynamodb tables
     runs-on: ubuntu-20.04
     env:
@@ -20,8 +22,8 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-          
+          aws-region: ${{ env.region }}
+
       - id: restore-tables-backups
         name: Restore to latest backup for dynamodb tables
         run: |-
@@ -32,7 +34,7 @@ jobs:
           fi
 
           echo "Running restore over $tables_to_restore"
-          
+
           for table in $tables_to_restore
             do
               backups=($(aws dynamodb list-backups --table-name $table | jq -r '.BackupSummaries | .[] | "\(.BackupCreationDateTime)::\(.BackupArn)" '))
@@ -46,16 +48,16 @@ jobs:
 
                 (( backup_time > younger_backup_time )) && younger_backup_time=$backup_time && younger_backup_arn=$backup_arn
               done
-              
+
               echo "Restoring from backup $younger_backup_arn"
 
               if test -z "$younger_backup_arn"; then
                 echo "Deleting $table"
-                
+
                 aws dynamodb wait table-not-exists --table-name $table
                 echo "Restoring from $younger_backup_arn"
                 aws dynamodb restore-table-from-backup --target-table-name $table --backup-arn $younger_backup_arn
               else
                 echo "No backup found for table $table"
-              fi 
+              fi
           done


### PR DESCRIPTION
Adding a new github action that will be automatically triggered when there are changes to infrastructure users in files:
      - 'infra/cluster_admins_*'
      - 'infra/cluster_users'
      - 'infra/biomage-read-only-group/**'
      - 'infra/botkube-configmap.yaml'
      - 'infra/cf-state-machine-role.yaml'

This part is currently done in `deploy-infra.yaml` manually.