### PR TITLE
Fix error when removing staging environments due to missing environment declaration

### DIFF
--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -9,6 +9,9 @@ on:
         description: 'Encrypted secrets to use for this task'
         required: true
 
+env:
+  region: 'eu-west-1'
+
 jobs:
   remove-staging:
     name: Remove staging environment


### PR DESCRIPTION
This adds the `env` object to the action responsible to remove staging environments, similarly to how it is added the rest of the files.