### PR TITLE
fix iam group resource path

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -169,8 +169,8 @@ Resources:
                   - "iam:ListMFADevices"
                   - "iam:ResyncMFADevice"
                 Resource:
-                  - "arn:aws:iam::*:user/${aws:username}"
-                  - "arn:aws:iam::*:group"
+                  - "arn:aws:iam::${AWS::AccountId}:user/${aws:username}"
+                  - "arn:aws:iam::${AWS::AccountId}:group/*"
 
         - PolicyName: "can-access-eventbridge"
           PolicyDocument:

--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -169,8 +169,8 @@ Resources:
                   - "iam:ListMFADevices"
                   - "iam:ResyncMFADevice"
                 Resource:
-                  - "arn:aws:iam::${AWS::AccountId}:user/${aws:username}"
-                  - "arn:aws:iam::${AWS::AccountId}:group/*"
+                  - "arn:aws:iam::*:user/${aws:username}"
+                  - "arn:aws:iam::*:group/*"
 
         - PolicyName: "can-access-eventbridge"
           PolicyDocument:


### PR DESCRIPTION
# Background
#### Link to issue 

This run to add permission errors because the IAM resources are not properly defined : 

https://github.com/biomage-ltd/iac/actions/runs/1653361016

The correct IAM identifier for group is : `arn:aws:iam::account:group/group-name-with-path`

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR