### PR TITLE
Add IAM account scoping

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -143,6 +143,7 @@ Resources:
                   - "iam:ChangePassword"
                   - "iam:GetUser"
                   - "iam:ListGroups"
+                  - "iam:GetGroup"
                   - "iam:ListPolicies"
                   - "iam:CreateAccessKey"
                   - "iam:DeleteAccessKey"
@@ -169,8 +170,8 @@ Resources:
                   - "iam:ListMFADevices"
                   - "iam:ResyncMFADevice"
                 Resource:
-                  - "arn:aws:iam::*:user/${aws:username}"
-                  - "arn:aws:iam::*:group/*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:user/${!aws:username}"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:group/*"
 
         - PolicyName: "can-access-eventbridge"
           PolicyDocument:


### PR DESCRIPTION
# Background
#### Link to issue 

- IAM access was not scoped to the account, so I added that, as we are going to deploy to another account
- Add the `GetGroup` permission so that users can look at the permissions defined in a group. This is to make checking whether permissions written in IAC are the same as the permissions attached to a group in IAM.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR