### PR TITLE
[BIOMAGE-716] - Change flux git poll interval

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -268,6 +268,8 @@ jobs:
             --set git.url=git@github.com:$GITHUB_REPOSITORY \
             --set git.path="releases/$CLUSTER_ENV" \
             --set git.label="flux-sync-$CLUSTER_ENV" \
+            --set git.pollInterval="2m" \
+            --set git.timeout="40s" \
             --set syncGarbageCollection.enabled=true \
             --namespace flux \
             --install --wait
@@ -275,7 +277,8 @@ jobs:
           helm upgrade helm-operator fluxcd/helm-operator \
             --set git.ssh.secretName=flux-git-deploy \
             --set helm.versions=v3 \
-            --set git.timeout=40s \
+            --set git.pollInterval="2m" \
+            --set git.timeout="40s" \
             --namespace flux \
             --install --wait
       


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-716

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

Added flux `git.pollInterval` property according to :
- https://github.com/fluxcd/flux/tree/master/chart/flux
- https://github.com/fluxcd/helm-operator/tree/master/chart/helm-operator

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR