### PR TITLE
[BIOMAGE-1673] Add concurrency limit on certain pipelines

### DIFF
--- a/.github/workflows/deploy-changed-users.yaml
+++ b/.github/workflows/deploy-changed-users.yaml
@@ -11,9 +11,9 @@ on:
 env:
   region: 'eu-west-1'
 
-# this ensures that only one CI pipeline executing
-# these steps can run at the same time
-concurrency: deploy-changed-users
+# this ensures that only one CI pipeline with the same key
+# can run at once in order to prevent undefined states
+concurrency: cluster-update-mutex
 
 jobs:
   check-secrets:

--- a/.github/workflows/deploy-changed-users.yaml
+++ b/.github/workflows/deploy-changed-users.yaml
@@ -11,6 +11,9 @@ on:
 env:
   region: 'eu-west-1'
 
+# this ensures that only one CI pipeline executing
+# these steps can run at the same time
+concurrency: deploy-changed-users
 
 jobs:
   check-secrets:

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -12,9 +12,9 @@ on:
 env:
   region: 'eu-west-1'
 
-# this ensures that only one CI pipeline executing
-# these steps can run at the same time
-concurrency: deploy-infra
+# this ensures that only one CI pipeline with the same key
+#  can run at once in order to prevent undefined states
+concurrency: cluster-update-mutex
 
 jobs:
   check-secrets:

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -12,6 +12,10 @@ on:
 env:
   region: 'eu-west-1'
 
+# this ensures that only one CI pipeline executing
+# these steps can run at the same time
+concurrency: deploy-infra
+
 jobs:
   check-secrets:
     name: Check if secrets are defined


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-1673

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
Added concurrency fields to two CI pipelines that must not run concurrently.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR