### PR TITLE
allow seeing user and group policies

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -142,9 +142,6 @@ Resources:
                 Action:
                   - "iam:ChangePassword"
                   - "iam:GetUser"
-                  - "iam:ListGroups"
-                  - "iam:GetGroup"
-                  - "iam:ListPolicies"
                   - "iam:CreateAccessKey"
                   - "iam:DeleteAccessKey"
                   - "iam:ListAccessKeys"
@@ -171,7 +168,27 @@ Resources:
                   - "iam:ResyncMFADevice"
                 Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:user/${!aws:username}"
+
+        - PolicyName: "can-see-user-and-group-policies"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "iam:ListUsers"
+                  - "iam:GetUser"
+                  - "iam:ListGroups"
+                  - "iam:GetGroup"
+                  - "iam:ListRoles"
+                  - "iam:GetRole"
+                  - "iam:ListPolicies"
+                  - "iam:GetPolicy"
+                  - "iam:GetRolePolicy"
+                Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:group/*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:user/*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:policy/*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/*"
 
         - PolicyName: "can-access-eventbridge"
           PolicyDocument:

--- a/infra/cf-iac-secret-key.yaml
+++ b/infra/cf-iac-secret-key.yaml
@@ -14,7 +14,7 @@ Resources:
       EnableKeyRotation: true
       Enabled: true
       KeyPolicy:
-        Version: '"2012-10-17"'
+        Version: "2012-10-17"
         Id: iac-secrets-key-policy
         Statement:
         - Sid: enable-root-management
@@ -40,6 +40,6 @@ Resources:
           Resource: '*'
   IACKeyAlias:
     Type: AWS::KMS::Alias
-    Properties: 
+    Properties:
       AliasName: alias/iac-secret-key
       TargetKeyId: !GetAtt IACKey.Arn


### PR DESCRIPTION
This PR is to add permissions so that developers can **view** (not update or delete) the policies associated with users and groups. This ability will make it much easier to debug permissions.