### PR TITLE
add permissions to see user groups and policies

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -178,10 +178,12 @@ Resources:
                   - "iam:ListUsers"
                   - "iam:GetUser"
                   - "iam:ListGroups"
+                  - "iam:ListGroupsForUser"
                   - "iam:GetGroup"
                   - "iam:ListRoles"
                   - "iam:GetRole"
                   - "iam:ListPolicies"
+                  - "iam:ListUserPolicies"
                   - "iam:GetPolicy"
                   - "iam:GetRolePolicy"
                 Resource:


### PR DESCRIPTION
PR 251 (https://github.com/hms-dbmi-cellenics/iac/pull/250) adds permissions to see users permissions. However, some additional permissions are required to see the roles and groups associated with a user. This PR adds those permissions.