### PR TITLE
add list attached user policies

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -184,6 +184,7 @@ Resources:
                   - "iam:GetRole"
                   - "iam:ListPolicies"
                   - "iam:ListUserPolicies"
+                  - "iam:ListAttachedUserPolicies"
                   - "iam:GetPolicy"
                   - "iam:GetRolePolicy"
                 Resource:


### PR DESCRIPTION
It seems that aside from being able to list user policies (#251), you also need to be able to list the attached user policies.