### PR TITLE
Add MFA resource to developers

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -170,6 +170,7 @@ Resources:
                   - "iam:ResyncMFADevice"
                 Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:user/${!aws:username}"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:mfa/${!aws:username}"
 
         - PolicyName: "can-see-user-and-group-policies"
           PolicyDocument:


### PR DESCRIPTION
Developers already have the `iam:CreateVirtualMFADevice` pemission to add their own virtual MFA device. However, this permission wasn't scoped to their accounts, so they can't use it.

This PR adds that resource to the permission.