### PR TITLE
Add rds read only access

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -244,12 +244,13 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}"
 
-        - PolicyName: "test-changes"
+        - PolicyName: "can-read-rds"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
-                  - "rds:DescribeDBClusterEndpoints"
+                  - "rds:Describe*"
+                  - "rds:ListTagsForResource"
                 Resource:
-                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}"
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:*"


### PR DESCRIPTION
Previous PR (#278) to add RDS readonly managed policy fails because we hit the max of 10 managed policy limit. This PR moves those permissions to inline permissions.