### PR TITLE
[BIOMAGE-1793] - Move RDS subnet and security group into a new stack

### DIFF
--- a/cf/rds-subnet-security-group.yaml
+++ b/cf/rds-subnet-security-group.yaml
@@ -1,0 +1,66 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Set up RDS Aurora cluster subnet and security groups [managed by github.com/hms-dbmi-cellenics/iac]
+
+Parameters:
+  Environment:
+    Type: String
+    Default: development
+    AllowedValues:
+      - development
+      - staging
+      - production
+    Description: The environment for which the cluster needs to be created.
+
+# --------------------------------------- Constants ---------------------------------------
+  DBPort:
+    Type: String
+    Default: "5432"
+# --------------------------------------- END Constants -----------------------------------
+
+Resources:
+  DBSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: !Sub Biomage subnet group for ${Environment}.
+      DBSubnetGroupName: !Sub rds-subnet-group-${Environment}
+      SubnetIds:
+        Fn::Split: [',', Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"]
+      Tags:
+        - Key: "Name"
+          Value: AuroraSubnetGroup
+
+  RDSSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "Biomage RDS security group for ${Environment}"
+      SecurityGroupEgress: []
+      SecurityGroupIngress:
+        - SourceSecurityGroupId:
+          # This is the important security group, SharedNodeSecurityGroup is supposed to be no longer in real use
+            Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::ClusterSecurityGroupId"
+          FromPort: !Ref DBPort
+          ToPort: !Ref DBPort
+          IpProtocol: tcp
+        - SourceSecurityGroupId:
+            Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSAgentSecurityGroupId"
+          FromPort: !Ref DBPort
+          ToPort: !Ref DBPort
+          IpProtocol: tcp
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-security-group"
+        - Key: StackName
+          Value: !Ref AWS::StackName
+      VpcId:
+        Fn::ImportValue:
+          !Sub "eksctl-biomage-${Environment}-cluster::VPC"
+
+Outputs:
+  DBSubnetGroup:
+    Value: !Ref DBSubnetGroup
+    Export:
+      Name: !Sub "biomage-${Environment}-rds::DBSubnetGroup"
+  RDSSecurityGroup:
+    Value: !Ref RDSSecurityGroup
+    Export:
+      Name: !Sub "biomage-${Environment}-rds::RDSSecurityGroup"

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -35,7 +35,9 @@ Resources:
       Engine: aurora-postgresql
       EngineMode: provisioned
       EngineVersion: !Ref DBEngineVersion
-      DBSubnetGroupName: !Ref DBSubnetGroup
+      DBSubnetGroupName:
+        Fn::ImportValue:
+          !Sub "biomage-${Environment}-rds::DBSubnetGroup"
       DBClusterIdentifier: !Join [ "-", ["aurora-cluster", !Ref Environment] ]
       DatabaseName: "aurora_db"
       Port: !Ref DBPort
@@ -48,19 +50,9 @@ Resources:
       SourceRegion: !Sub '${AWS::Region}'
       # Check if we want to change this
       StorageEncrypted: false
-      VpcSecurityGroupIds: 
-        - !Ref RDSSecurityGroup
-
-  DBSubnetGroup:
-    Type: AWS::RDS::DBSubnetGroup
-    Properties:
-      DBSubnetGroupDescription: !Sub Biomage subnet group for ${Environment}.
-      DBSubnetGroupName: !Sub rds-subnet-group-${Environment}
-      SubnetIds:
-        Fn::Split: [',', Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"]
-      Tags:
-        - Key: "Name"
-          Value: AuroraSubnetGroup
+      VpcSecurityGroupIds:
+        - Fn::ImportValue:
+            !Sub "biomage-${Environment}-rds::RDSSecurityGroup"
 
   DBInstance1:
     Type: AWS::RDS::DBInstance
@@ -70,29 +62,3 @@ Resources:
       Engine: aurora-postgresql
       AutoMinorVersionUpgrade: true
       PubliclyAccessible: false
-
-  RDSSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: !Sub "Biomage RDS security group for ${Environment}"
-      SecurityGroupEgress: []
-      SecurityGroupIngress:
-        - SourceSecurityGroupId: 
-          # This is the important security group, SharedNodeSecurityGroup is supposed to be no longer in real use
-            Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::ClusterSecurityGroupId"
-          FromPort: !Ref DBPort
-          ToPort: !Ref DBPort
-          IpProtocol: tcp
-        - SourceSecurityGroupId: 
-            Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSAgentSecurityGroupId"
-          FromPort: !Ref DBPort
-          ToPort: !Ref DBPort
-          IpProtocol: tcp
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-security-group"
-        - Key: StackName
-          Value: !Ref AWS::StackName
-      VpcId:
-        Fn::ImportValue:
-          !Sub "eksctl-biomage-${Environment}-cluster::VPC"

--- a/cf/test-rds.yaml
+++ b/cf/test-rds.yaml
@@ -39,7 +39,9 @@ Resources:
       Engine: aurora-postgresql
       EngineMode: provisioned
       EngineVersion: !Ref DBEngineVersion
-      DBSubnetGroupName: !Ref DBSubnetGroup
+      DBSubnetGroupName:
+        Fn::ImportValue:
+          !Sub "biomage-${Environment}-rds::DBSubnetGroup"
       DBClusterIdentifier: !Join [ "-", ["aurora-cluster", !Ref Environment, !Ref SandboxID] ]
       DatabaseName: "aurora_db"
       Port: !Ref DBPort
@@ -52,19 +54,9 @@ Resources:
       SourceRegion: !Sub '${AWS::Region}'
       # Check if we want to change this
       StorageEncrypted: false
-      VpcSecurityGroupIds: 
-        - !Ref RDSSecurityGroup
-
-  DBSubnetGroup:
-    Type: AWS::RDS::DBSubnetGroup
-    Properties:
-      DBSubnetGroupDescription: !Sub Biomage subnet group for ${Environment}.
-      DBSubnetGroupName: !Sub rds-subnet-group-${Environment}
-      SubnetIds:
-        Fn::Split: [',', Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"]
-      Tags:
-        - Key: "Name"
-          Value: AuroraSubnetGroup
+      VpcSecurityGroupIds:
+        - Fn::ImportValue:
+            !Sub "biomage-${Environment}-rds::RDSSecurityGroup"
 
   DBInstance1:
     Type: AWS::RDS::DBInstance
@@ -74,29 +66,3 @@ Resources:
       Engine: aurora-postgresql
       AutoMinorVersionUpgrade: true
       PubliclyAccessible: false
-
-  RDSSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: !Sub "Biomage RDS security group for ${Environment}"
-      SecurityGroupEgress: []
-      SecurityGroupIngress:
-        - SourceSecurityGroupId: 
-          # This is the important security group, SharedNodeSecurityGroup is supposed to be no longer in real use
-            Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::ClusterSecurityGroupId"
-          FromPort: !Ref DBPort
-          ToPort: !Ref DBPort
-          IpProtocol: tcp
-        - SourceSecurityGroupId: 
-            Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSAgentSecurityGroupId"
-          FromPort: !Ref DBPort
-          ToPort: !Ref DBPort
-          IpProtocol: tcp
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-security-group"
-        - Key: StackName
-          Value: !Ref AWS::StackName
-      VpcId:
-        Fn::ImportValue:
-          !Sub "eksctl-biomage-${Environment}-cluster::VPC"


### PR DESCRIPTION
# Background

Move RDS subnet and security group into a new stack so we can share them between instances.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1793

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR