### PR TITLE
add access to rds without sandbox

### DIFF
--- a/cf/irsa-api-role.yaml
+++ b/cf/irsa-api-role.yaml
@@ -243,3 +243,4 @@ Resources:
                   - "rds:DescribeDBClusterEndpoints"
                 Resource:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}-*"
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}"


### PR DESCRIPTION
Allow API access to RDS without sandbox ID. This is a temporary fix until we have instances with sandbox id