### PR TITLE
Output RDS host as text

### DIFF
--- a/.github/workflows/test-deploy-staging.yaml
+++ b/.github/workflows/test-deploy-staging.yaml
@@ -162,7 +162,8 @@ jobs:
             --region $REGION \
             --db-cluster-identifier aurora-cluster-staging-$SANDBOX_ID \
             --filter Name=db-cluster-endpoint-type,Values='writer' \
-            --query 'DBClusterEndpoints[0].Endpoint')
+            --query 'DBClusterEndpoints[0].Endpoint' \
+            --output text)
 
           PASSWORD=$(aws rds generate-db-auth-token \
             --hostname $RDSHOST \
@@ -170,10 +171,11 @@ jobs:
             --region $REGION \
             --username $USERNAME)
 
-          PGPASSWORD=$PASSWORD psql \
+          psql \
             --host=${RDSHOST} \
             --port=5432 \
             --username=${USERNAME} \
+            --password=${PASSWORD} \
             --dbname=aurora_db \
             -c '
             CREATE ROLE api_role WITH LOGIN;


### PR DESCRIPTION
# Background
#### Link to issue 

Value returned from the query included double-quotes ("") which mess the value up when used as parameter value. This PR changes the output to text.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR