### PR TITLE
[BIOMAGE-1793] - Add new staging workflow param

### DIFF
--- a/.github/workflows/test-deploy-staging.yaml
+++ b/.github/workflows/test-deploy-staging.yaml
@@ -8,6 +8,9 @@ on:
       sandbox-id:
         description: 'The sandbox ID to deploy under'
         required: true
+      stage-rds:
+        description: 'Should task deploy a new RDS instance'
+        required: true
       secrets:
         description: 'Encrypted secrets to use for this task'
         required: true
@@ -80,6 +83,7 @@ jobs:
           aws-region: ${{ env.region }}
 
       - id: get-rds-secrets
+        if: ${{ github.event.inputs.stage-rds == 'True' }}
         uses: abhilash1in/aws-secrets-manager-action@v2.0.0
         name: Export RDS secrets into environment variables
         with:
@@ -87,6 +91,7 @@ jobs:
           parse-json: true
 
       - id: check-rds-secrets
+        if: ${{ github.event.inputs.stage-rds == 'True' }}
         name: Check RDS secrets are fetched
         run: |-
           # These checks if the RDS username and passwords are set
@@ -156,9 +161,9 @@ jobs:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
       - id: deploy-template-rds
+        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.stage-rds == 'True'}}
         name: Deploy CloudFormation stack for RDS
         uses: aws-actions/aws-cloudformation-github-deploy@v1
-        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           parameter-overrides: "Environment=staging,SandboxID=${{ github.event.inputs.sandbox-id }}"
           name: ${{ steps.set-stack-name.outputs.rds-name }}
@@ -167,6 +172,7 @@ jobs:
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
       - id: setup-rds-roles
+        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.stage-rds == 'True'}}
         name: Setup RDS roles
         run: |-
           INSTANCE_ID=$(aws ec2 describe-instances \
@@ -188,10 +194,11 @@ jobs:
             echo "Failed getting RDS host with name $CLUSTER_NAME"
             exit 1
           fi
+          PG_PORT=5432
           SETUP_ROLES_CMD="
             PGPASSWORD=${AURORA_STAGING_PASSWORD} psql \
               --host=${RDSHOST} \
-              --port=5432 \
+              --port=${PG_PORT} \
               --username=${AURORA_STAGING_USERNAME} \
               --dbname=aurora_db <<EOF
                 CREATE ROLE api_role WITH LOGIN;

--- a/.github/workflows/test-deploy-staging.yaml
+++ b/.github/workflows/test-deploy-staging.yaml
@@ -8,9 +8,10 @@ on:
       sandbox-id:
         description: 'The sandbox ID to deploy under'
         required: true
-      stage-rds:
-        description: 'Should task deploy a new RDS instance'
-        required: true
+      with-rds:
+        description: 'Should task stage a new RDS instance'
+        default: 'False'
+        required: false
       secrets:
         description: 'Encrypted secrets to use for this task'
         required: true
@@ -83,7 +84,7 @@ jobs:
           aws-region: ${{ env.region }}
 
       - id: get-rds-secrets
-        if: ${{ github.event.inputs.stage-rds == 'True' }}
+        if: ${{ github.event.inputs.with-rds == 'True' }}
         uses: abhilash1in/aws-secrets-manager-action@v2.0.0
         name: Export RDS secrets into environment variables
         with:
@@ -91,7 +92,7 @@ jobs:
           parse-json: true
 
       - id: check-rds-secrets
-        if: ${{ github.event.inputs.stage-rds == 'True' }}
+        if: ${{ github.event.inputs.with-rds == 'True' }}
         name: Check RDS secrets are fetched
         run: |-
           # These checks if the RDS username and passwords are set
@@ -161,7 +162,7 @@ jobs:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
       - id: deploy-template-rds
-        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.stage-rds == 'True'}}
+        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds == 'True'}}
         name: Deploy CloudFormation stack for RDS
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
@@ -172,7 +173,7 @@ jobs:
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
       - id: setup-rds-roles
-        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.stage-rds == 'True'}}
+        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds == 'True'}}
         name: Setup RDS roles
         run: |-
           INSTANCE_ID=$(aws ec2 describe-instances \
@@ -194,11 +195,10 @@ jobs:
             echo "Failed getting RDS host with name $CLUSTER_NAME"
             exit 1
           fi
-          PG_PORT=5432
           SETUP_ROLES_CMD="
             PGPASSWORD=${AURORA_STAGING_PASSWORD} psql \
               --host=${RDSHOST} \
-              --port=${PG_PORT} \
+              --port=5432 \
               --username=${AURORA_STAGING_USERNAME} \
               --dbname=aurora_db <<EOF
                 CREATE ROLE api_role WITH LOGIN;


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1793

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
- Added a new workflow param to the TEST RDS deployment workflow which acts as a flag to deploy/not deploy new RDS instances. This will not impact the normal staging workflow.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR