### PR TITLE
revert input type back to string

### DIFF
--- a/.github/workflows/test-deploy-staging.yaml
+++ b/.github/workflows/test-deploy-staging.yaml
@@ -5,16 +5,20 @@ on:
       manifest:
         description: 'The manifest file to deploy (base64 encoded)'
         required: true
+        type: string
       sandbox-id:
         description: 'The sandbox ID to deploy under'
         required: true
+        type: string
       with-rds:
         description: 'Stage a new RDS instance'
-        default: 'False'
         required: false
+        default: 'False'
+        type: string
       secrets:
         description: 'Encrypted secrets to use for this task'
         required: true
+        type: string
 env:
   region: 'eu-west-1'
 

--- a/.github/workflows/test-deploy-staging.yaml
+++ b/.github/workflows/test-deploy-staging.yaml
@@ -10,9 +10,8 @@ on:
         required: true
       with-rds:
         description: 'Stage a new RDS instance'
-        default: false
+        default: 'False'
         required: false
-        type: boolean
       secrets:
         description: 'Encrypted secrets to use for this task'
         required: true
@@ -85,7 +84,7 @@ jobs:
           aws-region: ${{ env.region }}
 
       - id: get-rds-secrets
-        if: ${{ github.event.inputs.with-rds }}
+        if: ${{ github.event.inputs.with-rds == 'True' }}
         uses: abhilash1in/aws-secrets-manager-action@v2.0.0
         name: Export RDS secrets into environment variables
         with:
@@ -93,7 +92,7 @@ jobs:
           parse-json: true
 
       - id: check-rds-secrets
-        if: ${{ github.event.inputs.with-rds }}
+        if: ${{ github.event.inputs.with-rds == 'True' }}
         name: Check RDS secrets are fetched
         run: |-
           # These checks if the RDS username and passwords are set
@@ -163,7 +162,7 @@ jobs:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
       - id: deploy-template-rds
-        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds }}
+        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds == 'True' }}
         name: Deploy CloudFormation stack for RDS
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
@@ -174,7 +173,7 @@ jobs:
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
       - id: setup-rds-roles
-        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds }}
+        if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds == 'True' }}
         name: Setup RDS roles
         run: |-
           INSTANCE_ID=$(aws ec2 describe-instances \


### PR DESCRIPTION
# Background
#### Link to issue 

It turns out boolean inputs are not parsed as booleans: https://github.com/actions/runner/issues/1483.

According to the issue, the value of a boolean input is converted to a string. `false` as input is an empty string, meanwhile the value of `true` is a the string 'true'. As recommended in the thread, it's better to use a string input or make comparison rather than use a boolean value.

Passing a boolean value as a workflow input via PyGithub's dispatch workflow command causes the call to always fail, even though the correct data type is passed. This might be due to the fact above - that actually boolean inputs to workflows are actually strings.

So, in line with the problem above, I think it's better to cast boolean values to a string before passing it as input to a workflow.

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR