### PR TITLE
[BIOMAGE-1793] - Add SandboxID to RDS CF

### DIFF
--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -10,6 +10,10 @@ Parameters:
       - staging
       - production
     Description: The environment for which the cluster needs to be created.
+  SandboxID:
+    Type: String
+    Default: default
+    Description: The sandbox ID of the environment that this cluster is created for.
   DBInstanceType:
     Type: String
     Default: db.t4g.medium
@@ -42,7 +46,7 @@ Resources:
       DBSubnetGroupName:
         Fn::ImportValue:
           !Sub "biomage-${Environment}-rds::DBSubnetGroup"
-      DBClusterIdentifier: !Join [ "-", ["aurora-cluster", !Ref Environment] ]
+      DBClusterIdentifier: !Join [ "-", ["aurora-cluster", !Ref Environment, !Ref SandboxID] ]
       DatabaseName: "aurora_db"
       Port: !Ref DBPort
       # Can't be deleted before first setting this to false, should be true when we are done with the basic setup of db


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1793

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
- Add SandboxID to the CF template for RDS and use it to stage a new instance.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR