### PR TITLE
deleting old activites daily

### DIFF
--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -18,17 +18,29 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-1
 
-      # This will take everything OLDER THAN the last 500 step functions
-      # marked as staging and remove them.
-      - id: remove-old-envs
+      # This will take the oldest 500 staging step functions and remove them.
+      - id: remove-old-state-machines
         name: Remove old step functions from staging
         run: |-
           aws stepfunctions list-state-machines --output text \
             | grep staging \
             | sort -k2 \
-            | head -n -500 \
+            | head -n 500 \
             | awk '{print $4}' \
             | xargs -I {} aws stepfunctions delete-state-machine --state-machine-arn {}
+
+      # This will take the oldest 500 staging activities and remove them.
+      - id: remove-old-activities
+        name: Remove old step functions from staging
+        run: |-
+          aws stepfunctions list-activities --output text \
+            | grep staging \
+            | sort -k2 \
+            | head -n 500 \
+            | awk '{print $2}' \
+            | xargs -I {} aws stepfunctions delete-activity --activity-arn {}
+
+
       - id: send-to-slack
         name: Send failure notification to Slack
         if: failure()


### PR DESCRIPTION
Old activities were not being deleted so we reached the 2000 limit. More details: https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1650321760431649

Now the script removes also old activities in addition to old state machines (only for staging). 
**Note** once we get close to 100 pipelines run in production daily, we'll have to revisit this.