### PR TITLE
event exporter migrated to v2

### DIFF
--- a/charts/nodejs/templates/kubernetes-event-exporter.yaml
+++ b/charts/nodejs/templates/kubernetes-event-exporter.yaml
@@ -43,9 +43,9 @@ data:
       - name: "cleanup"
         webhook:
 {{ if eq .Values.kubernetes.env "production" }}
-          endpoint: https://api.scp.biomage.net/v1/kubernetesEvents
+          endpoint: https://api.scp.biomage.net/v2/kubernetesEvents
 {{ else }}
-          endpoint: https://api-{{ .Values.biomageCi.sandboxId }}.scp-staging.biomage.net/v1/kubernetesEvents
+          endpoint: https://api-{{ .Values.biomageCi.sandboxId }}.scp-staging.biomage.net/v2/kubernetesEvents
 {{ end }}
           headers:
             User-Agent: kube-event-exporter 1.0


### PR DESCRIPTION
Moving event exporter configuration to start using v2

# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1881

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this
https://github.com/hms-dbmi-cellenics/api/pull/350

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR