### PR TITLE
[BIOMAGE-1860] - Add rotating secrets to rds

### DIFF
--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -1,4 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
+# CF transform required to inject lamba required for secret rotation
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-secretsmanager.html
 Transform: AWS::SecretsManager-2020-07-23
 Description: Set up RDS Aurora cluster [managed by github.com/hms-dbmi-cellenics/iac]
 
@@ -60,6 +62,9 @@ Resources:
     Properties:
       SecretId: !Ref RDSMasterUserSecret
       HostedRotationLambda:
+        # AWS provided Lambda to rotate single user for PostgreSQL
+        # https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#sar-template-postgre-singleuser
+        # This lambda will be injected into the stack. Injection requires AWS transform defined above.
         RotationType: PostgreSQLSingleUser
         RotationLambdaName: !Sub "RDSSecretsManagerRotation${Environment}"
         VpcSubnetIds:
@@ -91,7 +96,6 @@ Resources:
       EnableIAMDatabaseAuthentication: true
       BackupRetentionPeriod: 5
       SourceRegion: !Sub '${AWS::Region}'
-      # Check if we want to change this
       StorageEncrypted: false
       VpcSecurityGroupIds:
         - Fn::ImportValue:

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -63,7 +63,7 @@ Resources:
         RotationType: PostgreSQLSingleUser
         RotationLambdaName: !Sub "RDSSecretsManagerRotation${Environment}"
         VpcSubnetIds:
-          Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"
+          Fn::Split: [',', Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"]
         VpcSecurityGroupIds:
           Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSSecurityGroup"
       RotationRules:

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -41,7 +41,10 @@ Resources:
   RDSMasterUserSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
-      Description: RDS master secret
+      Description: |-
+        RDS master secret. Refrain from using this secret as it breaks the IAM
+        permission model that we have implemented to access the RDS. You should use
+        dev_role to access the RDS - it has the same permissions as the db root user.
       Name: !Sub "${DBSecretPrefix}-${Environment}"
       GenerateSecretString:
         SecretStringTemplate: '{"username": "postgres"}'

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -63,9 +63,9 @@ Resources:
         RotationType: PostgreSQLSingleUser
         RotationLambdaName: !Sub "RDSSecretsManagerRotation${Environment}"
         VpcSubnetIds:
-          Fn::Split: [',', Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"]
+          Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"
         VpcSecurityGroupIds:
-          Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSSecurityGroup"
+          Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::ClusterSecurityGroupId"
       RotationRules:
         Duration: 2h
         ScheduleExpression: 'cron(0 8 1 * ? *)'

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -35,6 +35,52 @@ Parameters:
     Default: aurora
 
 Resources:
+  RDSMasterUserSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: RDS master secret
+      Name: !Sub "${DBSecretPrefix}-${Environment}"
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "postgres"}'
+        GenerateStringKey: password
+        PasswordLength: 32
+        ExcludeCharacters: "/@\"'\\"
+
+  RDSMasterUserSecretPolicy:
+    Type: AWS::SecretsManager::ResourcePolicy
+    Properties:
+      SecretId: !Ref RDSMasterUserSecret
+      ResourcePolicy:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: Deny
+          Principal: "*"
+          Action: "*"
+          Resource: !Ref RDSMasterUserSecret
+
+  RDSInstanceAttachment:
+    Type: AWS::SecretsManager::SecretTargetAttachment
+    Properties:
+      SecretId: !Ref RDSMasterUserSecret
+      TargetId: !Ref DBInstance1
+      TargetType: AWS::RDS::DBInstance
+
+  RDSSecretRotationSchedule:
+    Type: AWS::SecretsManager::RotationSchedule
+    DependsOn: RDSInstanceAttachment
+    Properties:
+      SecretId: !Ref RDSMasterUserSecret
+      HostedRotationLambda:
+        RotationType: PostgreSQLSingleUser
+        RotationLambdaName: !Sub "RDS ${Environment} secrets manager rotation"
+        VpcSubnetIds:
+          Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"
+        VpcSecurityGroupIds:
+          Fn::ImportValue: !Sub "biomage-${Environment}-rds::RDSSecurityGroup"
+      RotationRules:
+        Duration: 2h
+        ScheduleExpression: 'cron(0 8 1 * ? *)'
+
   DBCluster:
     Type: AWS::RDS::DBCluster
     DeletionPolicy: Snapshot
@@ -51,8 +97,8 @@ Resources:
       Port: !Ref DBPort
       # Can't be deleted before first setting this to false, should be true when we are done with the basic setup of db
       DeletionProtection: false
-      MasterUsername: !Join ["", ["{{resolve:secretsmanager:", !Join ['-', [!Ref DBSecretPrefix, !Ref Environment]], ":SecretString:username}}" ]]
-      MasterUserPassword: !Join ["", ["{{resolve:secretsmanager:", !Join ['-', [!Ref DBSecretPrefix, !Ref Environment]], ":SecretString:password}}" ]]
+      MasterUsername: !Sub "{{resolve:secretsmanager:${RDSMasterUserSecret}::username}}"
+      MasterUserPassword: !Sub "{{resolve:secretsmanager:${RDSMasterUserSecret}::password}}"
       EnableIAMDatabaseAuthentication: true
       BackupRetentionPeriod: 5
       SourceRegion: !Sub '${AWS::Region}'

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::SecretsManager-2020-07-23
 Description: Set up RDS Aurora cluster [managed by github.com/hms-dbmi-cellenics/iac]
 
 Parameters:
@@ -46,18 +47,6 @@ Resources:
         PasswordLength: 32
         ExcludeCharacters: "/@\"'\\"
 
-  RDSMasterUserSecretPolicy:
-    Type: AWS::SecretsManager::ResourcePolicy
-    Properties:
-      SecretId: !Ref RDSMasterUserSecret
-      ResourcePolicy:
-        Version: "2012-10-17"
-        Statement:
-        - Effect: Deny
-          Principal: "*"
-          Action: "*"
-          Resource: !Ref RDSMasterUserSecret
-
   RDSInstanceAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment
     Properties:
@@ -72,7 +61,7 @@ Resources:
       SecretId: !Ref RDSMasterUserSecret
       HostedRotationLambda:
         RotationType: PostgreSQLSingleUser
-        RotationLambdaName: !Sub "RDS ${Environment} secrets manager rotation"
+        RotationLambdaName: !Sub "RDSSecretsManagerRotation${Environment}"
         VpcSubnetIds:
           Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"
         VpcSecurityGroupIds:

--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -96,7 +96,7 @@ Resources:
       EnableIAMDatabaseAuthentication: true
       BackupRetentionPeriod: 5
       SourceRegion: !Sub '${AWS::Region}'
-      StorageEncrypted: false
+      StorageEncrypted: true
       VpcSecurityGroupIds:
         - Fn::ImportValue:
             !Sub "biomage-${Environment}-rds::RDSSecurityGroup"


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1860

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
- Added rotation for the secret
- Added resource-based policy for the secret

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR