### PR TITLE
versioning, lifecycle and migration script added to s3 buckets

### DIFF
--- a/cf/s3-v2.yaml
+++ b/cf/s3-v2.yaml
@@ -26,6 +26,15 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
             BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   CellSetsBucket:
     Type: AWS::S3::Bucket
@@ -41,6 +50,15 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
             BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   WorkerResultsBucket:
     Type: AWS::S3::Bucket
@@ -99,6 +117,15 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
             BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   # Stores, for each experiment and timestamp, the log and dump files for errors from the pipeline
   # Indexed by experimentId and timestamp
@@ -163,6 +190,15 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
             BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   BackupsBucket:
     Type: AWS::S3::Bucket

--- a/cf/s3.yaml
+++ b/cf/s3.yaml
@@ -21,6 +21,15 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   CellSetsBucket:
     Type: AWS::S3::Bucket
@@ -31,6 +40,15 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   WorkerResultsBucket:
     Type: AWS::S3::Bucket
@@ -79,6 +97,15 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   # Stores, for each experiment and timestamp, the log and dump files for errors from the pipeline
   # Indexed by experimentId and timestamp
@@ -128,6 +155,15 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Non-current versions are stored in normal S3 for
+          # 7 days and are then deleted.
+          - Id: PreserveThenDeleteNonCurrentVersion
+            Status: "Enabled"
+            NoncurrentVersionExpirationInDays: 7
 
   BackupsBucket:
     Type: AWS::S3::Bucket

--- a/migrations/s3-migrations/migrateToUniqueBuckets.sh
+++ b/migrations/s3-migrations/migrateToUniqueBuckets.sh
@@ -5,9 +5,10 @@ accound_id="242905224710"
 
 for environment in ${environments[@]}; do
   for bucket in ${old_buckets[@]}; do
-    echo "--------- migrating $bucket_name to $new_bucket_name ---------"
     bucket_name="${bucket}-${environment}"
     new_bucket_name="${bucket}-${environment}-${accound_id}"
+    echo "--------- migrating $bucket_name to $new_bucket_name ---------"
+
     aws s3 sync s3://${bucket_name} s3://${new_bucket_name}
   done
 done

--- a/migrations/s3-migrations/migrateToUniqueBuckets.sh
+++ b/migrations/s3-migrations/migrateToUniqueBuckets.sh
@@ -1,3 +1,13 @@
-aws s3 mb s3://[new-bucket]
-aws s3 sync s3://[old-bucket] s3://[new-bucket]
-aws s3 rb --force s3://[old-bucket]
+
+old_buckets=("plots-tables" "cell-sets" "worker-results" "processed-matrix" "biomage-pipeline-debug" "biomage-source" "biomage-filtered-cells" "biomage-backups" "biomage-originals" "biomage-public-datasets") 
+environments=("staging" "production")
+accound_id="242905224710"
+
+for environment in ${environments[@]}; do
+  for bucket in ${old_buckets[@]}; do
+    echo "--------- migrating $bucket_name to $new_bucket_name ---------"
+    bucket_name="${bucket}-${environment}"
+    new_bucket_name="${bucket}-${environment}-${accound_id}"
+    aws s3 sync s3://${bucket_name} s3://${new_bucket_name}
+  done
+done

--- a/migrations/s3-migrations/migrateToUniqueBuckets.sh
+++ b/migrations/s3-migrations/migrateToUniqueBuckets.sh
@@ -1,7 +1,7 @@
 
 old_buckets=("plots-tables" "cell-sets" "worker-results" "processed-matrix" "biomage-pipeline-debug" "biomage-source" "biomage-filtered-cells" "biomage-backups" "biomage-originals" "biomage-public-datasets") 
 environments=("staging" "production")
-accound_id="242905224710"
+accound_id=$(aws sts get-caller-identity --query Account --output text)
 
 for environment in ${environments[@]}; do
   for bucket in ${old_buckets[@]}; do


### PR DESCRIPTION
# Background
bucket versioning, lifecycle and migration script for the new s3 buckets is added. Check [this](https://this-is-biomage.slack.com/archives/C015CHSUDRU/p1654181289578149) thread for more insight.
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1876
#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR