### PR TITLE
Add migrate commands

### DIFF
--- a/migrations/sql-migrations/Makefile
+++ b/migrations/sql-migrations/Makefile
@@ -13,3 +13,11 @@ copy-data:
 		venv/bin/python3 dynamo_to_json.py --source-env=${SOURCE_ENV};\
 	fi
 	@SOURCE_ENV=${SOURCE_ENV} TARGET_ENV=${TARGET_ENV} npm run dynamoToSql
+
+migrate:
+	@echo "Migrating database schema for ${TARGET_ENV}"
+	@NODE_ENV=${TARGET_ENV} knex migrate:latest
+
+migrate-down:
+	@echo "Deleting database schema for ${TARGET_ENV}"
+	@NODE_ENV=${TARGET_ENV} knex migrate:down

--- a/migrations/sql-migrations/dynamoToSql/Helper.js
+++ b/migrations/sql-migrations/dynamoToSql/Helper.js
@@ -75,7 +75,12 @@ class Helper {
   
   sqlInsertSample = async (experimentId, sample) => {
 
-    if (Array.isArray(sample)) {
+      if (
+        !sample.uuid
+        || !sample.name
+        || !sample.createdDate
+        || !sample.lastModified
+    ) {
         console.warn(`[ MALFORMED ] - e: ${experimentId}: This sample doesn't meet the required format:`)
         console.log(sample)
         return
@@ -92,7 +97,7 @@ class Helper {
 
     return await this.sqlInsert(sqlSample, 'sample');
   };
-  
+
   sqlInsertSampleFile = async (sampleFileUuid, projectUuid, sample, fileName, file) => {
 
     const sampleFileTypeEnumKey = this.sampleFileTypeDynamoToEnum[fileName] || 'nil';

--- a/migrations/sql-migrations/dynamoToSql/Helper.js
+++ b/migrations/sql-migrations/dynamoToSql/Helper.js
@@ -74,6 +74,13 @@ class Helper {
   };
   
   sqlInsertSample = async (experimentId, sample) => {
+
+    if (Array.isArray(sample)) {
+        console.warn(`[ MALFORMED ] - e: ${experimentId}: This sample doesn't meet the required format:`)
+        console.log(sample)
+        return
+    }
+
     const sqlSample = {
       id: sample.uuid,
       experiment_id: experimentId,
@@ -82,12 +89,13 @@ class Helper {
       created_at: sample.createdDate,
       updated_at: sample.lastModified,
     };
-    
+
     return await this.sqlInsert(sqlSample, 'sample');
   };
   
   sqlInsertSampleFile = async (sampleFileUuid, projectUuid, sample, fileName, file) => {
-    const sampleFileTypeEnumKey = this.sampleFileTypeDynamoToEnum[fileName];
+
+    const sampleFileTypeEnumKey = this.sampleFileTypeDynamoToEnum[fileName] || 'nil';
 
     const s3Path = `${projectUuid}/${sample.uuid}/${fileName}`;
 
@@ -101,7 +109,7 @@ class Helper {
       sample_file_type: sampleFileTypeEnumKey,
       size: fileSize,
       s3_path: s3Path,
-      upload_status: file.upload.status,
+      upload_status: file.upload?.status || "uploaded",
       updated_at: file.lastModified
     };
 


### PR DESCRIPTION
# Background
1.  Add `make` migration commands
It is not easy to remember that you have to run `NODE_ENV=staging knex migrate` to do a migration, so I added Make commands to make it easier. Commands added : 

- `migrate TARGET_ENV=...`
- `migrate-down TARGET_ENV=...`

2. Handle cases of malformed samples when migrating
The migration runners failed to insert data when it encounter cases where samples are malformed. I added checks so that the script still runs when it encounters malformed samples.