### PR TITLE
[BIOMAGE-1933] - Add permissions to list example datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/cf/cognito-case-insensitive.yaml
+++ b/cf/cognito-case-insensitive.yaml
@@ -92,7 +92,7 @@ Resources:
                   - "s3:ListBucket"
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
-        - PolicyName: !Sub "can-list-obects-in-public-datasets-${Environment}-bucket"
+        - PolicyName: !Sub "can-list-objects-in-public-datasets-${Environment}-bucket"
           PolicyDocument:
             Version: "2012-10-17"
             Statement:

--- a/cf/cognito-case-insensitive.yaml
+++ b/cf/cognito-case-insensitive.yaml
@@ -92,6 +92,15 @@ Resources:
                   - "s3:ListBucket"
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
+        - PolicyName: !Sub "can-list-obects-in-public-datasets-${Environment}-bucket"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:ListBucket"
+                Resource:
+                  - !Sub "arn:aws:s3:::biomage-public-datasets-${Environment}"
         - PolicyName: !Sub "can-get-public-datasets-${Environment}"
           PolicyDocument:
             Version: "2012-10-17"


### PR DESCRIPTION
# Background
Cognito users (the UI) needs permissions to list objects in the `biomage-public-datasets` bucket.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1933

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR