### PR TITLE
Rename account config key

### DIFF
--- a/infra/account-config.yaml
+++ b/infra/account-config.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-awsAccount:
+myAccount:
   domainName: FILLED_IN_BY_CI
   region: FILLED_IN_BY_CI
   accountId: FILLED_IN_BY_CI


### PR DESCRIPTION
# Background
The key under `account-config` is named `awsAccount`. However, looking the [CI](https://github.com/hms-dbmi-cellenics/iac/blob/master/.github/workflows/deploy-infra.yaml#L223-L226) fills in values under `myAccount`. I'm renaming to match closer to what the CI fills in.