### PR TITLE
1928 fix permissions of api_role

### DIFF
--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -207,6 +207,7 @@ jobs:
                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public to api_role;
                 GRANT dev_role TO ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME};
                 ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
+                ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO api_role;
                 REVOKE dev_role FROM ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME};
                 GRANT rds_iam TO api_role;
                 GRANT rds_iam, ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME} TO dev_role;

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -204,6 +204,7 @@ jobs:
                 CREATE ROLE api_role WITH LOGIN;
                 CREATE ROLE dev_role WITH LOGIN;
                 GRANT USAGE ON SCHEMA public TO api_role;
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public to api_role;
                 GRANT dev_role TO ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME};
                 ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
                 REVOKE dev_role FROM ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME};

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -219,6 +219,7 @@ jobs:
                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public to api_role;
                 GRANT dev_role TO ${AURORA_STAGING_USERNAME};
                 ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
+                ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO api_role;
                 REVOKE dev_role FROM ${AURORA_STAGING_USERNAME};
                 GRANT rds_iam TO api_role;
                 GRANT rds_iam, ${AURORA_STAGING_USERNAME} TO dev_role;

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -216,6 +216,7 @@ jobs:
                 CREATE ROLE api_role WITH LOGIN;
                 CREATE ROLE dev_role WITH LOGIN;
                 GRANT USAGE ON SCHEMA public TO api_role;
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public to api_role;
                 GRANT dev_role TO ${AURORA_STAGING_USERNAME};
                 ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
                 REVOKE dev_role FROM ${AURORA_STAGING_USERNAME};


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
This PR fixes a permissions issue when interacting with the [SERIAL data type](https://www.postgresql.org/docs/8.1/datatype.html#DATATYPE-SERIAL) in postgres.

The api needs special permissions to be able to insert and receive the result of performing an insert into a table that has a SERIAL column, otherwise we get the same error that is brought up [here](https://stackoverflow.com/questions/9325017/error-permission-denied-for-sequence-cities-id-seq-using-postgres).

We use a SERIAL to generate internal usage ids in the metadata_track table, so basically the api failed when we tried to create a new metadata track, this fixes it (tested by connecting to the db and running the commands that are added here, after this it seems that `api_role` has the necessary permissiosn to perform the insert).

This is not reproducible in local development but it canb e tested in staging that it works [here](https://ui-martinfosco-ui723.scp-staging.biomage.net/data-management)

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR