### PR TITLE
Update permissions for new s3 buckets

### DIFF
--- a/cf/bioinformatics-access-group.yaml
+++ b/cf/bioinformatics-access-group.yaml
@@ -35,9 +35,9 @@ Resources:
                   - 's3:PutObject'
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS:AccountId}/*"
+                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}/*"
-                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS:AccountId}/*"
+                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"
 
         - PolicyName: !Sub "can-list-${Environment}-source"
           PolicyDocument:
@@ -49,9 +49,9 @@ Resources:
                   - 's3:GetBucketLocation'
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
-                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS:AccountId}"
+                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}"
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}"
-                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS:AccountId}"
+                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}"
 
         - PolicyName: !Sub "can-update-${Environment}-experiment-data"
           PolicyDocument:

--- a/cf/bioinformatics-access-group.yaml
+++ b/cf/bioinformatics-access-group.yaml
@@ -35,7 +35,9 @@ Resources:
                   - 's3:PutObject'
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}/*"
+                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS:AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}/*"
+                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS:AccountId}/*"
 
         - PolicyName: !Sub "can-list-${Environment}-source"
           PolicyDocument:
@@ -47,7 +49,9 @@ Resources:
                   - 's3:GetBucketLocation'
                 Resource:
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}"
+                  - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS:AccountId}"
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}"
+                  - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS:AccountId}"
 
         - PolicyName: !Sub "can-update-${Environment}-experiment-data"
           PolicyDocument:

--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -69,7 +69,9 @@ Resources:
                 Action: 's3:*'
                 Resource:
                   - !Sub "arn:aws:s3:::*-${Environment}/*"
+                  - !Sub "arn:aws:s3:::*-${Environment}-${AWS:AccountId}/*"
                   - !Sub "arn:aws:s3:::*-${Environment}"
+                  - !Sub "arn:aws:s3:::*-${Environment}-${AWS:AccountId}"
 
         - PolicyName: "can-create-xray-groups"
           PolicyDocument:

--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -69,9 +69,9 @@ Resources:
                 Action: 's3:*'
                 Resource:
                   - !Sub "arn:aws:s3:::*-${Environment}/*"
-                  - !Sub "arn:aws:s3:::*-${Environment}-${AWS:AccountId}/*"
+                  - !Sub "arn:aws:s3:::*-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::*-${Environment}"
-                  - !Sub "arn:aws:s3:::*-${Environment}-${AWS:AccountId}"
+                  - !Sub "arn:aws:s3:::*-${Environment}-${AWS::AccountId}"
 
         - PolicyName: "can-create-xray-groups"
           PolicyDocument:


### PR DESCRIPTION
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1960

#### Links to any Tickets related to this
https://biomage.atlassian.net/browse/BIOMAGE-1876
https://biomage.atlassian.net/browse/BIOMAGE-1911

#### Code changes
Added developer and bioinformatics permissions for new s3 buckets.

#### Definition of DONE
- [ ]    Developers & bioinformatician can see the new S3 buckets either in AWS console or using the aws CLI (e.g.: aws s3 ls biomage-filtered-cells-production-242905224710

- [ ]    biomage unstage does not trigger any error

- [ ]    ui-default works correctly.

