### PR TITLE
[BIOMAGE-1978] - Add manual trigger to deploy changed CF

### DIFF
--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -103,6 +103,16 @@ jobs:
           echo "$(jq -c . < ${HOME}/cf_files.json)"
           echo "::set-output name=num-files::$(jq '. | length' ${HOME}/cf_files.json)"
 
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+
+      - id: lint
+        name: Lint template
+        uses: scottbrenner/cfn-lint-action@1.6.1
+        with:
+          args: ${{ steps.check-number-of-cf-files.outputs.files }}
+
   deploy-templates:
     name: Deploy changed CloudFormation template
     runs-on: ubuntu-20.04
@@ -117,16 +127,6 @@ jobs:
     env:
       CLUSTER_ENV: ${{ matrix.environment }}
     steps:
-      - id: checkout
-        name: Check out source code
-        uses: actions/checkout@v2
-
-      - id: lint
-        name: Lint template
-        uses: scottbrenner/cfn-lint-action@1.6.1
-        with:
-          args: ${{ matrix.template }}
-
       - id: set-up-creds
         name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -103,6 +103,18 @@ jobs:
           echo "$(jq -c . < ${HOME}/cf_files.json)"
           echo "::set-output name=num-files::$(jq '. | length' ${HOME}/cf_files.json)"
 
+  lint-templates:
+    name: Lint template files
+    runs-on: ubuntu-20.04
+    needs: get-modified-templates
+    if: needs.get-modified-templates.outputs.num-files > 0
+    strategy:
+      matrix:
+        environment: ${{ fromJson(needs.setup.outputs.matrix) }}
+        template: ${{fromJson(needs.get-modified-templates.outputs.files)}}
+    env:
+      CLUSTER_ENV: ${{ matrix.environment }}
+    steps:
       - id: checkout
         name: Check out source code
         uses: actions/checkout@v2
@@ -116,8 +128,8 @@ jobs:
   deploy-templates:
     name: Deploy changed CloudFormation template
     runs-on: ubuntu-20.04
-    needs: get-modified-templates
-    if: needs.get-modified-templates.outputs.num-files > 0
+    needs: lint-templates
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
     outputs:
       deploy-rds: ${{ steps.set-name.outputs.deploy-rds && github.ref == 'refs/heads/master' }}
     strategy:
@@ -127,6 +139,10 @@ jobs:
     env:
       CLUSTER_ENV: ${{ matrix.environment }}
     steps:
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+
       - id: set-up-creds
         name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -137,7 +153,7 @@ jobs:
 
       # This is only necessary for IAM Service Account roles.
       - id: get-oidc
-        if: ${{ contains(matrix.template, 'irsa-') && github.ref == 'refs/heads/master' }}
+        if: ${{ contains(matrix.template, 'irsa-') }}
         name: Get OIDC provider information for IRSA role
         run: |-
           OIDC_PROVIDER=$(aws eks describe-cluster --name "biomage-$CLUSTER_ENV" --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
@@ -161,7 +177,7 @@ jobs:
 
       - id: deploy-template
         name: Deploy CloudFormation template
-        if: ${{ !contains(matrix.template, 'irsa-') && github.ref == 'refs/heads/master' }}
+        if: ${{ !contains(matrix.template, 'irsa-') }}
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:
           parameter-overrides: "Environment=${{ matrix.environment }}"
@@ -171,7 +187,7 @@ jobs:
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND"
 
       - id: deploy-irsa-template
-        if: ${{ contains(matrix.template, 'irsa-') && github.ref == 'refs/heads/master' }}
+        if: ${{ contains(matrix.template, 'irsa-') }}
         name: Deploy IRSA CloudFormation template
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         with:

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -63,12 +63,12 @@ jobs:
       - id: set-matrix
         name: Set up cluster matrix
         run: |-
-          if [ "${CLUSTER}" = "staging" ]; then
+          if [ "${GITHUB_REF}" == "refs/heads/master" ] || [ "${CLUSTER}" = "staging and production" ]; then
+            echo '::set-output name=matrix::["staging", "production"]'
+          elif [ "${CLUSTER}" = "staging" ]; then
             echo '::set-output name=matrix::["staging"]'
           elif [ "${CLUSTER}" = "production" ]; then
             echo '::set-output name=matrix::["production"]'
-          elif [ "${CLUSTER}" = "staging and production" ] || [ "${GITHUB_REF}" == "refs/heads/master" ]; then
-            echo '::set-output name=matrix::["staging", "production"]'
           fi
         env:
           CLUSTER: ${{ github.event.inputs.cluster }}
@@ -130,7 +130,7 @@ jobs:
     name: Deploy changed CloudFormation template
     runs-on: ubuntu-20.04
     needs: lint-templates
-    if: github.ref == 'refs/heads/master' || github.event.type == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/master' || github.event.type == 'WorkflowDispatch'
     outputs:
       deploy-rds: ${{ steps.set-name.outputs.deploy-rds && github.ref == 'refs/heads/master' }}
     strategy:

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -1,5 +1,15 @@
 name: Deploy changed CloudFormation templates
 on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        type: choice
+        description: Select environment to deploy to
+        options:
+        - staging
+        - production
+        - staging and production
+        default: staging
   push:
     branches:
       - master
@@ -14,6 +24,54 @@ on:
       - 'cf/**.yml'
 env:
   region: 'eu-west-1'
+
+# this ensures that only one CI pipeline with the same key
+#  can run at once in order to prevent undefined states
+concurrency: cluster-update-mutex
+
+jobs:
+  setup:
+    name: Check secrets and set up matrix
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: check-secrets
+        name: Check if necessary secrets are installed.
+        run: |-
+          echo Checking if secrets are defined in the repository.
+
+          if [ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ]
+          then
+            echo AWS Access Key ID not defined.
+            ERROR=true
+          fi
+
+          if [ -z "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]
+          then
+            echo AWS Secret Access Key not defined.
+            ERROR=true
+          fi
+
+          if [ ! -z "$ERROR" ]
+          then
+            echo
+            echo This workflow requires some secrets to complete. The secrets can be set/rotated
+            echo by running `rotate-ci` from `biomage-utils`.
+            false
+          fi
+      - id: set-matrix
+        name: Set up cluster matrix
+        run: |-
+          if [ "${CLUSTER}" = "staging" ]; then
+            echo '::set-output name=matrix::["staging"]'
+          elif [ "${CLUSTER}" = "production" ]; then
+            echo '::set-output name=matrix::["production"]'
+          elif [ "${CLUSTER}" = "staging and production" ]; then
+            echo '::set-output name=matrix::["staging", "production"]'
+          fi
+        env:
+          CLUSTER: ${{ github.event.inputs.cluster }}
 
 jobs:
   get-modified-templates:
@@ -55,7 +113,7 @@ jobs:
       deploy-rds: ${{ steps.set-name.outputs.deploy-rds && github.ref == 'refs/heads/master' }}
     strategy:
       matrix:
-        environment: ['production', 'staging']
+        environment: ${{ fromJson(needs.setup.outputs.matrix) }}
         template: ${{fromJson(needs.get-modified-templates.outputs.files)}}
     env:
       CLUSTER_ENV: ${{ matrix.environment }}
@@ -131,7 +189,7 @@ jobs:
     if: ${{ needs.deploy-templates.outputs.deploy-rds == 'true' }}
     strategy:
       matrix:
-        environment: ['production', 'staging']
+        environment: ${{ fromJson(needs.setup.outputs.matrix) }}
     env:
       CLUSTER_ENV: ${{ matrix.environment }}
     steps:

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -27,7 +27,7 @@ env:
 
 # this ensures that only one CI pipeline with the same key
 #  can run at once in order to prevent undefined states
-concurrency: cluster-update-mutex
+concurrency: cf-update-mutex
 
 jobs:
   setup:

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -73,7 +73,6 @@ jobs:
         env:
           CLUSTER: ${{ github.event.inputs.cluster }}
 
-jobs:
   get-modified-templates:
     name: Fetch paths to modified CloudFormation templates
     runs-on: ubuntu-20.04

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -67,11 +67,12 @@ jobs:
             echo '::set-output name=matrix::["staging"]'
           elif [ "${CLUSTER}" = "production" ]; then
             echo '::set-output name=matrix::["production"]'
-          elif [ "${CLUSTER}" = "staging and production" ]; then
+          elif [ "${CLUSTER}" = "staging and production" ] || [ "${GITHUB_REF}" == "refs/heads/master" ]; then
             echo '::set-output name=matrix::["staging", "production"]'
           fi
         env:
           CLUSTER: ${{ github.event.inputs.cluster }}
+          GITHUB_REF: ${{ github.ref }}
 
   get-modified-templates:
     name: Fetch paths to modified CloudFormation templates
@@ -129,7 +130,7 @@ jobs:
     name: Deploy changed CloudFormation template
     runs-on: ubuntu-20.04
     needs: lint-templates
-    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/master' || github.event.type == 'workflow_dispatch'
     outputs:
       deploy-rds: ${{ steps.set-name.outputs.deploy-rds && github.ref == 'refs/heads/master' }}
     strategy:


### PR DESCRIPTION
# Background
RIght now we have to do some workarounds to test CF changes in staging.

This PR adds a manual trigger to the deploy-changed-cf action.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1978

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR