### PR TITLE
removing staging release file from ./releases repo

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -172,7 +172,6 @@ jobs:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
       - name: Push staging deployment template to releases
-        if: (github.event_name == 'pull_request' || github.event_name == 'push') && matrix.environment == 'staging'
         uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -125,12 +125,22 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
-      - id: add-manifest-to-repo
-        name: Add manifest file to repository.
+      - id: remove-manifest-from-repo
+        name: Remove manifest file from repository.
         run: |-
           rm ./releases/staging/$SANDBOX_ID.yaml
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+
+      - name: Remove manifest files from releases
+        uses: kafkasl/remove_from_another_repo_action@0.0.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          path: ./staging/$SANDBOX_ID.yaml
+          destination_repo: ${{ github.repository_owner }}/releases
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'
 
       - id: set-name
         name: Set name of the CloudFormation stack for SNS topic and Cognito pool


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR