### PR TITLE
[BIOMAGE-1973] - Point flux to releases repo

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -18,7 +18,8 @@ on:
         - staging and production
         default: staging
 env:
-  region: 'eu-west-1'
+  REGION: 'eu-west-1'
+  RELEASES_REPOSITORY: hms-dbmi-cellenics/releases
 
 # this ensures that only one CI pipeline with the same key
 #  can run at once in order to prevent undefined states
@@ -108,7 +109,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.region }}
+          aws-region: ${{ env.REGION }}
 
       - id: install-yq
         name: Install yq for modifying the eksctl yaml spec.
@@ -118,7 +119,7 @@ jobs:
       - id: fill-metadata
         name: Add name and region to the eksctl file.
         run: |-
-          yq w infra/cluster.yaml metadata.name "biomage-$CLUSTER_ENV" | yq w - metadata.region ${{ env.region }} > /tmp/cluster-$CLUSTER_ENV.yaml
+          yq w infra/cluster.yaml metadata.name "biomage-$CLUSTER_ENV" | yq w - metadata.region ${{ env.REGION }} > /tmp/cluster-$CLUSTER_ENV.yaml
           cat /tmp/cluster-$CLUSTER_ENV.yaml
 
       - id: install-eksctl
@@ -195,7 +196,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.region }}
+          aws-region: ${{ env.REGION }}
 
       - id: add-kubeconfig
         name: Add k8s config file for existing cluster.
@@ -243,7 +244,7 @@ jobs:
 
           cat infra/account-config.yaml
         env:
-          AWS_REGION: ${{ env.region }}
+          AWS_REGION: ${{ env.REGION }}
           AWS_ACCOUNT_ID: ${{ steps.setup-aws.outputs.aws-account-id }}
           DOMAIN_NAME: ${{ steps.setup-domain.outputs.domain-name }}
 
@@ -342,8 +343,8 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml
 
           helm upgrade flux fluxcd/flux \
-            --set git.url=git@github.com:$GITHUB_REPOSITORY \
-            --set git.path="releases/$CLUSTER_ENV" \
+            --set git.url=git@github.com:${{ env.RELEASES_REPOSITORY }} \
+            --set git.path="$CLUSTER_ENV" \
             --set git.label="flux-sync-$CLUSTER_ENV" \
             --set git.pollInterval="2m" \
             --set git.timeout="40s" \
@@ -370,7 +371,7 @@ jobs:
           # find existing key IDs. save them to a file
           curl \
             -H"Authorization: token $API_TOKEN_GITHUB"\
-            https://api.github.com/repos/$GITHUB_REPOSITORY/keys 2>/dev/null\
+            https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys 2>/dev/null\
             | jq '.[] | select(.title | contains(env.CLUSTER_ENV)) | .id' > /tmp/key_ids
 
           # iterate through them and delete all existing deploy keys
@@ -380,7 +381,7 @@ jobs:
               curl \
                 -X "DELETE"\
                 -H"Authorization: token $API_TOKEN_GITHUB"\
-                https://api.github.com/repos/$GITHUB_REPOSITORY/keys/$_id 2>/dev/null
+                https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys/$_id 2>/dev/null
             done
 
           # add the keyfile to github
@@ -391,7 +392,7 @@ jobs:
             curl \
               -i\
               -H"Authorization: token $API_TOKEN_GITHUB"\
-              --data @- https://api.github.com/repos/$GITHUB_REPOSITORY/keys << EOF
+              --data @- https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys << EOF
             {
               "title" : "Flux CI -- $CLUSTER_ENV -- $(date)",
               "key" : "$(cat ~/flux.pub)",

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -392,7 +392,7 @@ jobs:
             curl \
               -i\
               -H"Authorization: token $API_TOKEN_GITHUB"\
-              --data @- https://api.github.com/repos/$GITHUB_REPOSITORY/keys << EOF
+              --data @- https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys << EOF
             {
               "title" : "Flux CI -- $CLUSTER_ENV -- $(date)",
               "key" : "$(cat ~/flux.pub)",

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -19,7 +19,7 @@ on:
         default: staging
 env:
   REGION: 'eu-west-1'
-  RELEASES_REPOSITORY: hms-dbmi-cellenics/releases
+  RELEASES_REPOSITORY: $GITHUB_REPOSITORY_OWNER/releases
 
 # this ensures that only one CI pipeline with the same key
 #  can run at once in order to prevent undefined states

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -371,7 +371,7 @@ jobs:
           # find existing key IDs. save them to a file
           curl \
             -H"Authorization: token $API_TOKEN_GITHUB"\
-            https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys 2>/dev/null\
+            https://api.github.com/repos/$GITHUB_REPOSITORY/keys 2>/dev/null\
             | jq '.[] | select(.title | contains(env.CLUSTER_ENV)) | .id' > /tmp/key_ids
 
           # iterate through them and delete all existing deploy keys
@@ -381,7 +381,7 @@ jobs:
               curl \
                 -X "DELETE"\
                 -H"Authorization: token $API_TOKEN_GITHUB"\
-                https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys/$_id 2>/dev/null
+                https://api.github.com/repos/$GITHUB_REPOSITORY/keys/$_id 2>/dev/null
             done
 
           # add the keyfile to github

--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -371,7 +371,7 @@ jobs:
           # find existing key IDs. save them to a file
           curl \
             -H"Authorization: token $API_TOKEN_GITHUB"\
-            https://api.github.com/repos/$GITHUB_REPOSITORY/keys 2>/dev/null\
+            https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys 2>/dev/null\
             | jq '.[] | select(.title | contains(env.CLUSTER_ENV)) | .id' > /tmp/key_ids
 
           # iterate through them and delete all existing deploy keys
@@ -381,7 +381,7 @@ jobs:
               curl \
                 -X "DELETE"\
                 -H"Authorization: token $API_TOKEN_GITHUB"\
-                https://api.github.com/repos/$GITHUB_REPOSITORY/keys/$_id 2>/dev/null
+                https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys/$_id 2>/dev/null
             done
 
           # add the keyfile to github
@@ -392,7 +392,7 @@ jobs:
             curl \
               -i\
               -H"Authorization: token $API_TOKEN_GITHUB"\
-              --data @- https://api.github.com/repos/${{ env.RELEASES_REPOSITORY }}/keys << EOF
+              --data @- https://api.github.com/repos/$GITHUB_REPOSITORY/keys << EOF
             {
               "title" : "Flux CI -- $CLUSTER_ENV -- $(date)",
               "key" : "$(cat ~/flux.pub)",

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -160,7 +160,7 @@ jobs:
       - id: create-manifest-file
         name: Create manifest file to repository.
         run: |-
-          echo "$MANIFEST" | base64 -d > ./releases/staging/$SANDBOX_ID.yaml
+          echo "$MANIFEST" | base64 -d > $SANDBOX_ID.yaml
         env:
           MANIFEST: ${{ github.event.inputs.manifest }}
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
@@ -254,7 +254,7 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source_file: ./releases/staging/${{ github.event.inputs.sandbox-id }}.yaml
+          source_file: ${{ github.event.inputs.sandbox-id }}.yaml
           destination_repo: ${{ github.repository_owner }}/releases
           destination_folder: staging
           user_email: ci@biomage.net

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -77,6 +77,12 @@ jobs:
           aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
           aws-region: ${{ env.region }}
 
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+
       - id: setup-aws-privileged
         name: Configure AWS privileged credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -229,7 +235,6 @@ jobs:
       - id: deploy-template-sns
         name: Deploy CloudFormation stack for SNS topic
         uses: aws-actions/aws-cloudformation-github-deploy@v1
-        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           parameter-overrides: "Environment=staging,SandboxID=${{ github.event.inputs.sandbox-id }}"
           name: ${{ steps.set-stack-name.outputs.sns-name }}
@@ -240,7 +245,6 @@ jobs:
       - id: deploy-template-cognito
         name: Deploy CloudFormation stack for Cognito pool clients
         uses: aws-actions/aws-cloudformation-github-deploy@v1
-        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           parameter-overrides: "Environment=staging,SandboxID=${{ github.event.inputs.sandbox-id }}"
           name: ${{ steps.set-stack-name.outputs.cognito-name }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -77,6 +77,12 @@ jobs:
           aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
           aws-region: ${{ env.region }}
 
+      - id: checkout
+        name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+
       - id: setup-aws-privileged
         name: Configure AWS privileged credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -157,10 +163,10 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
-      - id: create-manifest-file
-        name: Create manifest file to repository.
+      - id: add-manifest-to-repo
+        name: Add manifest file to repository.
         run: |-
-          echo "$MANIFEST" | base64 -d > $SANDBOX_ID.yaml
+          echo "$MANIFEST" | base64 -d > ./releases/staging/$SANDBOX_ID.yaml
         env:
           MANIFEST: ${{ github.event.inputs.manifest }}
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
@@ -248,13 +254,56 @@ jobs:
           no-fail-on-empty-changeset: "1"
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      - id: push-deployment-to-releases
-        name: Push staging deployment template to releases
+      - id: disable-admin-enforcement
+        name: Temporarily disable admin enforcement
+        uses: benjefferies/branch-protection-bot@1.0.7
+        with:
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
+          owner: ${{ github.repository_owner }}
+          repo: iac
+          enforce_admins: false
+          retries: 8
+
+      - id: pull
+        name: Pull and allow unrelated histories.
+        run: |-
+          git pull --allow-unrelated-histories
+
+      - id: push-deployment
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Deploy staging environment ${{ github.event.inputs.sandbox-id }}
+
+      - id: on-failure-retry
+        if: failure()
+        name: Retry in case push failed.
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 30
+          max_attempts: 5
+          retry_on: error
+          command: git config user.name "GitHub Actions" && git pull --allow-unrelated-histories --no-edit && git push origin master
+          # Add jitter to break up correlated events.
+          on_retry_command: sleep $((5 + RANDOM % 10))
+
+      - id: enable-admin-enforcement
+        name: Re-enable admin enforcement
+        uses: benjefferies/branch-protection-bot@1.0.7
+        if: always()
+        with:
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
+          owner: ${{ github.repository_owner }}
+          repo: iac
+          enforce_admins: true
+          retries: 8
+
+
+      - name: Push staging deployment template to releases
         uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source_file: ${{ github.event.inputs.sandbox-id }}.yaml
+          source_file: ./releases/staging/${{ github.event.inputs.sandbox-id }}.yaml
           destination_repo: ${{ github.repository_owner }}/releases
           destination_folder: staging
           user_email: ci@biomage.net

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -163,14 +163,6 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
-      - id: create-manifest-file
-        name: Create manifest file to repository.
-        run: |-
-          echo "$MANIFEST" | base64 -d > $SANDBOX_ID.yaml
-        env:
-          MANIFEST: ${{ github.event.inputs.manifest }}
-          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
-
       - id: deploy-template-rds
         if: ${{ github.ref == 'refs/heads/master' && github.event.inputs.with-rds == 'True' }}
         name: Deploy CloudFormation stack for RDS
@@ -251,6 +243,14 @@ jobs:
           template: cf/userpoolclient.yaml
           no-fail-on-empty-changeset: "1"
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
+
+      - id: create-manifest-file
+        name: Create manifest file to repository.
+        run: |-
+          echo "$MANIFEST" | base64 -d > $SANDBOX_ID.yaml
+        env:
+          MANIFEST: ${{ github.event.inputs.manifest }}
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
       - id: push-deployment-to-releases
         name: Push staging deployment template to releases

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -77,12 +77,6 @@ jobs:
           aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
           aws-region: ${{ env.region }}
 
-      - id: checkout
-        name: Check out source code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.API_TOKEN_GITHUB }}
-
       - id: setup-aws-privileged
         name: Configure AWS privileged credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -163,10 +157,10 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
-      - id: add-manifest-to-repo
-        name: Add manifest file to repository.
+      - id: create-manifest-file
+        name: Create manifest file to repository.
         run: |-
-          echo "$MANIFEST" | base64 -d > ./releases/staging/$SANDBOX_ID.yaml
+          echo "$MANIFEST" | base64 -d > $SANDBOX_ID.yaml
         env:
           MANIFEST: ${{ github.event.inputs.manifest }}
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
@@ -254,56 +248,13 @@ jobs:
           no-fail-on-empty-changeset: "1"
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      - id: disable-admin-enforcement
-        name: Temporarily disable admin enforcement
-        uses: benjefferies/branch-protection-bot@1.0.7
-        with:
-          access_token: ${{ secrets.API_TOKEN_GITHUB }}
-          owner: ${{ github.repository_owner }}
-          repo: iac
-          enforce_admins: false
-          retries: 8
-
-      - id: pull
-        name: Pull and allow unrelated histories.
-        run: |-
-          git pull --allow-unrelated-histories
-
-      - id: push-deployment
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Deploy staging environment ${{ github.event.inputs.sandbox-id }}
-
-      - id: on-failure-retry
-        if: failure()
-        name: Retry in case push failed.
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 30
-          max_attempts: 5
-          retry_on: error
-          command: git config user.name "GitHub Actions" && git pull --allow-unrelated-histories --no-edit && git push origin master
-          # Add jitter to break up correlated events.
-          on_retry_command: sleep $((5 + RANDOM % 10))
-
-      - id: enable-admin-enforcement
-        name: Re-enable admin enforcement
-        uses: benjefferies/branch-protection-bot@1.0.7
-        if: always()
-        with:
-          access_token: ${{ secrets.API_TOKEN_GITHUB }}
-          owner: ${{ github.repository_owner }}
-          repo: iac
-          enforce_admins: true
-          retries: 8
-
-
-      - name: Push staging deployment template to releases
+      - id: push-deployment-to-releases
+        name: Push staging deployment template to releases
         uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source_file: ./releases/staging/${{ github.event.inputs.sandbox-id }}.yaml
+          source_file: ${{ github.event.inputs.sandbox-id }}.yaml
           destination_repo: ${{ github.repository_owner }}/releases
           destination_folder: staging
           user_email: ci@biomage.net

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -77,12 +77,6 @@ jobs:
           aws-secret-access-key: ${{ steps.decrypt-secrets.outputs.aws-secret-access-key }}
           aws-region: ${{ env.region }}
 
-      - id: checkout
-        name: Check out source code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.API_TOKEN_GITHUB }}
-
       - id: setup-aws-privileged
         name: Configure AWS privileged credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -163,8 +157,8 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
-      - id: add-manifest-to-repo
-        name: Add manifest file to repository.
+      - id: create-manifest-file
+        name: Create manifest file to repository.
         run: |-
           echo "$MANIFEST" | base64 -d > ./releases/staging/$SANDBOX_ID.yaml
         env:
@@ -254,51 +248,8 @@ jobs:
           no-fail-on-empty-changeset: "1"
           capabilities: "CAPABILITY_IAM,CAPABILITY_NAMED_IAM"
 
-      - id: disable-admin-enforcement
-        name: Temporarily disable admin enforcement
-        uses: benjefferies/branch-protection-bot@1.0.7
-        with:
-          access_token: ${{ secrets.API_TOKEN_GITHUB }}
-          owner: ${{ github.repository_owner }}
-          repo: iac
-          enforce_admins: false
-          retries: 8
-
-      - id: pull
-        name: Pull and allow unrelated histories.
-        run: |-
-          git pull --allow-unrelated-histories
-
-      - id: push-deployment
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Deploy staging environment ${{ github.event.inputs.sandbox-id }}
-
-      - id: on-failure-retry
-        if: failure()
-        name: Retry in case push failed.
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 30
-          max_attempts: 5
-          retry_on: error
-          command: git config user.name "GitHub Actions" && git pull --allow-unrelated-histories --no-edit && git push origin master
-          # Add jitter to break up correlated events.
-          on_retry_command: sleep $((5 + RANDOM % 10))
-
-      - id: enable-admin-enforcement
-        name: Re-enable admin enforcement
-        uses: benjefferies/branch-protection-bot@1.0.7
-        if: always()
-        with:
-          access_token: ${{ secrets.API_TOKEN_GITHUB }}
-          owner: ${{ github.repository_owner }}
-          repo: iac
-          enforce_admins: true
-          retries: 8
-
-
-      - name: Push staging deployment template to releases
+      - id: push-deployment-to-releases
+        name: Push staging deployment template to releases
         uses: dmnemec/copy_file_to_another_repo_action@v1.0.4
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}

--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -86,7 +86,6 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
-
       - id: wait-pending-removals
         name: Wait for previous removal jobs before proceeding
         uses: softprops/turnstyle@v1
@@ -125,23 +124,6 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
-      - id: remove-manifest-from-repo
-        name: Remove manifest file from repository.
-        run: |-
-          rm ./releases/staging/$SANDBOX_ID.yaml
-        env:
-          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
-
-      - name: Remove manifest files from releases
-        uses: kafkasl/delete_from_another_repo@0.0.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          path: ./staging/${{ github.event.inputs.sandbox-id }}.yaml
-          destination_repo: ${{ github.repository_owner }}/releases
-          user_email: ci@biomage.net
-          user_name: 'Biomage CI/CD'
-
       - id: set-name
         name: Set name of the CloudFormation stack for SNS topic and Cognito pool
         run: |-
@@ -177,45 +159,13 @@ jobs:
         env:
           STACK_NAME: ${{ steps.set-name.outputs.cognito-name }}
 
-      - id: disable-admin-enforcement
-        name: Temporarily disable admin enforcement
-        uses: benjefferies/branch-protection-bot@1.0.7
+      - id: delete-staging-manifest
+        name: Remove manifest files from releases
+        uses: kafkasl/delete_from_another_repo@0.0.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          access_token: ${{ secrets.API_TOKEN_GITHUB }}
-          owner: ${{ github.repository_owner }}
-          repo: iac
-          enforce_admins: false
-          retries: 8
-
-      - id: pull
-        name: Pull and allow unrelated histories.
-        run: |-
-          git pull --allow-unrelated-histories
-
-      - id: push-deployment
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Remove staging environment ${{ github.event.inputs.sandbox-id }}
-
-      - id: on-failure-retry
-        if: failure()
-        name: Retry in case push failed.
-        uses: nick-invision/retry@v2
-        with:
-          timeout_seconds: 30
-          max_attempts: 5
-          retry_on: error
-          command: git config user.name "GitHub Actions" && git pull --allow-unrelated-histories --no-edit && git push origin master
-          # Add jitter to break up correlated events.
-          on_retry_command: sleep $[($RANDOM % 10) + 5]s
-
-      - id: enable-admin-enforcement
-        name: Re-enable admin enforcement
-        uses: benjefferies/branch-protection-bot@1.0.7
-        if: always()
-        with:
-          access_token: ${{ secrets.API_TOKEN_GITHUB }}
-          owner: ${{ github.repository_owner }}
-          repo: iac
-          enforce_admins: true
-          retries: 8
+          path: ./staging/${{ github.event.inputs.sandbox-id }}.yaml
+          destination_repo: ${{ github.repository_owner }}/releases
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'

--- a/.github/workflows/remove-staging.yaml
+++ b/.github/workflows/remove-staging.yaml
@@ -86,6 +86,7 @@ jobs:
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
 
+
       - id: wait-pending-removals
         name: Wait for previous removal jobs before proceeding
         uses: softprops/turnstyle@v1
@@ -124,6 +125,23 @@ jobs:
         env:
           SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
 
+      - id: remove-manifest-from-repo
+        name: Remove manifest file from repository.
+        run: |-
+          rm ./releases/staging/$SANDBOX_ID.yaml
+        env:
+          SANDBOX_ID: ${{ github.event.inputs.sandbox-id }}
+
+      - name: Remove manifest files from releases
+        uses: kafkasl/delete_from_another_repo@0.0.1
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          path: ./staging/${{ github.event.inputs.sandbox-id }}.yaml
+          destination_repo: ${{ github.repository_owner }}/releases
+          user_email: ci@biomage.net
+          user_name: 'Biomage CI/CD'
+
       - id: set-name
         name: Set name of the CloudFormation stack for SNS topic and Cognito pool
         run: |-
@@ -159,13 +177,45 @@ jobs:
         env:
           STACK_NAME: ${{ steps.set-name.outputs.cognito-name }}
 
-      - id: delete-staging-manifest
-        name: Remove manifest files from releases
-        uses: kafkasl/delete_from_another_repo@0.0.1
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      - id: disable-admin-enforcement
+        name: Temporarily disable admin enforcement
+        uses: benjefferies/branch-protection-bot@1.0.7
         with:
-          path: ./staging/${{ github.event.inputs.sandbox-id }}.yaml
-          destination_repo: ${{ github.repository_owner }}/releases
-          user_email: ci@biomage.net
-          user_name: 'Biomage CI/CD'
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
+          owner: ${{ github.repository_owner }}
+          repo: iac
+          enforce_admins: false
+          retries: 8
+
+      - id: pull
+        name: Pull and allow unrelated histories.
+        run: |-
+          git pull --allow-unrelated-histories
+
+      - id: push-deployment
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Remove staging environment ${{ github.event.inputs.sandbox-id }}
+
+      - id: on-failure-retry
+        if: failure()
+        name: Retry in case push failed.
+        uses: nick-invision/retry@v2
+        with:
+          timeout_seconds: 30
+          max_attempts: 5
+          retry_on: error
+          command: git config user.name "GitHub Actions" && git pull --allow-unrelated-histories --no-edit && git push origin master
+          # Add jitter to break up correlated events.
+          on_retry_command: sleep $[($RANDOM % 10) + 5]s
+
+      - id: enable-admin-enforcement
+        name: Re-enable admin enforcement
+        uses: benjefferies/branch-protection-bot@1.0.7
+        if: always()
+        with:
+          access_token: ${{ secrets.API_TOKEN_GITHUB }}
+          owner: ${{ github.repository_owner }}
+          repo: iac
+          enforce_admins: true
+          retries: 8


### PR DESCRIPTION
# Background
We want to decouple the [releases](https://github.com/hms-dbmi-cellenics/releases) folder from IAC. To do this, we have to : 
- Make flux point to the releases repo.
- Delete the deploy key from this repo, so that it can be added to the releases repo. Deleting has to be done manully, adding is done inside the deploy-infra script because keys are generated after flux is deployed.
- Run the deploy biomage-infra script to deploy the changes so that flux points to `releases`

#### Deployment
After this PR is merged and the corresponding `biomage-utils` PR is merged, we have to : 
- ~~Delete the staging deploy key from this repo~~
- ~~Run Deploy biomage infra workflow > configure for staging~~
- ~~Test that staging / unstaging works~~

Once staging is up and working, we have to:
- ~~Delete the production deploy key from this repo~~
- ~~Run Deploy biomage infra workflow > configure for production~~
- ~~Check that production is working~~

#### Notes
- In this implementation, the new staging deployment file is created inside the workflow runner. This file is then copied over to the `releases` repo using [dmnemec/copy_file_to_another_repo_action](https://github.com/dmnemec/copy_file_to_another_repo_action). Internally this plugin clones the target repo, copies the file into the repo, commit and pushes the changes.
- In the case a user creates a new staging using a sandbox id that already exists in the cluster, the staging step will fail when trying to create a fargateprofile for the worker in the cluster and stop subsequent staging steps from happening. This happens because the namespace to create the fargate profile in already exists. If we want to handle this issue, we can add a step in `biomage stage` which checks for the uniqueness of the sandbox id. However, I think sandbox id collision is rare (sandbox_id are prefixed by names, so a concious effort has to be done to use the same id), so I don't think implementing this check is worth the effort.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1973

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this
https://github.com/hms-dbmi-cellenics/biomage-utils/pull/100

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR