### PR TITLE
adding setup reqs for setup-rds roles

### DIFF
--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -217,7 +217,7 @@ jobs:
   setup-rds-roles:
     name: Setup RDS roles for default resources
     runs-on: ubuntu-20.04
-    needs: deploy-templates
+    needs: [setup, deploy-templates]
     if: ${{ needs.deploy-templates.outputs.deploy-rds == 'true' }}
     strategy:
       matrix:


### PR DESCRIPTION
setup-rds-roles needs the `setup` step to be in the `needs` section because otherwise it can't use an output from that step.