### PR TITLE
Make RDSSecretRotationSchedule sandbox-id specific

### DIFF
--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -79,7 +79,10 @@ Resources:
         # https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_available-rotation-templates.html#sar-template-postgre-singleuser
         # This lambda will be injected into the stack. Injection requires AWS transform defined above.
         RotationType: PostgreSQLSingleUser
-        RotationLambdaName: !Sub "RDSSecretsManagerRotation${Environment}"
+        RotationLambdaName: !If [SandboxIdIsDefault, 
+          !Sub "RDSSecretsManagerRotation${Environment}", 
+          !Sub "RDSSecretsManagerRotation${Environment}-${SandboxID}"
+        ]
         VpcSubnetIds:
           Fn::ImportValue: !Sub "eksctl-biomage-${Environment}-cluster::SubnetsPrivate"
         VpcSecurityGroupIds:


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR