### PR TITLE
add permission to list global clusters

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -197,10 +197,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - rds:DescribeClusters
-                Resource:
-                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
-              - Effect: Allow
-                Action:
                   - rds:DescribeDBClusterEndpoints
                 Resource:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}"

--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -186,12 +186,17 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "rds-db:connect"
+                  - rds-db:connect
                 Resource:
                   - !Sub "arn:aws:rds-db:${AWS::Region}:${AWS::AccountId}:dbuser:*/dev_role"
               - Effect: Allow
                 Action:
-                  - "rds:DescribeDBClusterEndpoints"
+                  - rds:DescribeGlobalClusters
+                Resource:
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:global-cluster:*"
+              - Effect: Allow
+                Action:
+                  - rds:DescribeDBClusterEndpoints
                 Resource:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}"
 

--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -196,6 +196,11 @@ Resources:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:global-cluster:*"
               - Effect: Allow
                 Action:
+                  - rds:DescribeClusters
+                Resource:
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
+              - Effect: Allow
+                Action:
                   - rds:DescribeDBClusterEndpoints
                 Resource:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:aurora-cluster-${Environment}"


### PR DESCRIPTION
# Background
We can not see the cluster names in the web console - only the endpoint name. This makes it hard to see the RDS resources. These permissions show us what DB clusters are available.

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR