### PR TITLE
[BIOMAGE-1967] - Allow deletion of staging rds

### DIFF
--- a/cf/rds.yaml
+++ b/cf/rds.yaml
@@ -105,7 +105,7 @@ Resources:
       DBClusterIdentifier: !Join [ "-", ["aurora-cluster", !Ref Environment, !Ref SandboxID] ]
       DatabaseName: "aurora_db"
       Port: !Ref DBPort
-      DeletionProtection: true
+      DeletionProtection: !If [SandboxIdIsDefault, true, false]
       MasterUsername: !Sub "{{resolve:secretsmanager:${RDSMasterUserSecret}::username}}"
       MasterUserPassword: !Sub "{{resolve:secretsmanager:${RDSMasterUserSecret}::password}}"
       EnableIAMDatabaseAuthentication: true


### PR DESCRIPTION
# Background
Right now deletion protection for all RDS instances are protected from deletion. This doesn't allow us to delete RDS instances which are staged for testing purposes. The changes in this PR allows deletion of RDS instances created only for testing in staging, which are instances whose `sandboxId` is not `default`.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1967

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR