### PR TITLE
Correct RDS setup command expansion

### DIFF
--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -314,7 +314,7 @@ jobs:
               EOF"
           aws ssm send-command --instance-ids "$INSTANCE_ID" \
             --document-name AWS-RunShellScript \
-            --parameters "commands='$SETUP_ROLES_CMD'"
+            --parameters 'commands="'"$SETUP_ROLES_CMD"'"'
         env:
           REGION: ${{ env.region }}
 


### PR DESCRIPTION
# Background
The RDS setup roles command is throwing an error. It seems to be caused by incorrect expansion of parameters: https://github.com/hms-dbmi-cellenics/iac/runs/7279973903?check_suite_focus=true

![image](https://user-images.githubusercontent.com/2862362/178246121-e64cb80d-350e-41f9-8e59-577f5a9d2c2d.png)

This StackOverflow answer provides an alternative way: https://stackoverflow.com/a/13802438/1940886. Instead of trying to work around the substitutions, the answer suggests to concatenate the string. This PR made changs according to the recommendation.

#### Link to issue 
N/A

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR