### PR TITLE
[BIOMAGE-2020] different url for the hms deployment

### DIFF
--- a/.github/workflows/backup-cognito-users.yaml
+++ b/.github/workflows/backup-cognito-users.yaml
@@ -11,8 +11,9 @@ jobs:
   backup-users:
     name: create backup of cognito users
     runs-on: ubuntu-20.04
-    matrix:
-      environment-name: [Biomage, HMS]
+    strategy:
+      matrix:
+        environment-name: [Biomage, HMS]
     environment: ${{ matrix.environment-name }}
     steps:
       - id: setup-node

--- a/.github/workflows/backup-cognito-users.yaml
+++ b/.github/workflows/backup-cognito-users.yaml
@@ -11,7 +11,9 @@ jobs:
   backup-users:
     name: create backup of cognito users
     runs-on: ubuntu-20.04
-    environment: [Biomage, HMS]
+    matrix:
+      environment-name: [Biomage, HMS]
+    environment: ${{ matrix.environment-name }}
     steps:
       - id: setup-node
         uses: actions/setup-node@v2

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -11,7 +11,9 @@ jobs:
   run-e2e:
     name: Delete old staging step functions
     runs-on: ubuntu-20.04
-    environment: [Biomage, HMS]
+    matrix:
+      environment-name: [Biomage, HMS]
+    environment: ${{ matrix.environment-name }}
     steps:
       - id: setup-aws
         name: Configure AWS credentials

--- a/.github/workflows/delete-unused-step-functions.yaml
+++ b/.github/workflows/delete-unused-step-functions.yaml
@@ -11,8 +11,9 @@ jobs:
   run-e2e:
     name: Delete old staging step functions
     runs-on: ubuntu-20.04
-    matrix:
-      environment-name: [Biomage, HMS]
+    strategy:
+      matrix:
+        environment-name: [Biomage, HMS]
     environment: ${{ matrix.environment-name }}
     steps:
       - id: setup-aws

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -155,7 +155,7 @@ jobs:
       max-parallel: 1
       matrix:
         environment-type: ${{ fromJson(needs.setup.outputs.matrix) }}
-        environment-name: [HMS]
+        environment-name: [Biomage, HMS]
         template: ${{fromJson(needs.get-modified-templates.outputs.files)}}
         exclude:
           - environment-name: HMS

--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -155,7 +155,7 @@ jobs:
       max-parallel: 1
       matrix:
         environment-type: ${{ fromJson(needs.setup.outputs.matrix) }}
-        environment-name: [Biomage, HMS]
+        environment-name: [HMS]
         template: ${{fromJson(needs.get-modified-templates.outputs.files)}}
         exclude:
           - environment-name: HMS

--- a/cf/cognito-case-insensitive.yaml
+++ b/cf/cognito-case-insensitive.yaml
@@ -172,4 +172,4 @@ Resources:
     Type: AWS::Cognito::UserPoolDomain
     Properties:
       UserPoolId: !Ref UserPool
-      Domain: !Sub "biomage-auth-${Environment}-${AWS::AccountId}"
+      Domain: !If [isHMSAccount, !Sub "hms-auth-${Environment}-${AWS::AccountId}", !Sub "biomage-auth-${Environment}-${AWS::AccountId}"]


### PR DESCRIPTION
# Background
In this doc: https://docs.google.com/document/d/1yt8a3Gc-J7WuJRVzQEfv1jVlggwBoXgXBRvK_0NLdLE/edit# Alex pointed out that we shouldn't have biomage in the url for auth. I am changing it, so that for the hms deployment, it says hms.
I have done a quick fix with hardcoded hms value, because for all other potential future deployments, it is fine to have biomage in the link.

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR