### PR TITLE
[BIOMAGE-1938] - Allow worker to download work result

### DIFF
--- a/cf/irsa-worker-role.yaml
+++ b/cf/irsa-worker-role.yaml
@@ -71,7 +71,7 @@ Resources:
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}/*"
-                  - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}"
+                  - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::processed-matrix-${Environment}-${AWS::AccountId}/*"
 
         - PolicyName: !Sub "can-upload-object-to-destination-bucket-${Environment}"

--- a/cf/irsa-worker-role.yaml
+++ b/cf/irsa-worker-role.yaml
@@ -71,6 +71,7 @@ Resources:
                   - !Sub "arn:aws:s3:::biomage-source-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::biomage-originals-${Environment}-${AWS::AccountId}/*"
                   - !Sub "arn:aws:s3:::cell-sets-${Environment}-${AWS::AccountId}/*"
+                  - !Sub "arn:aws:s3:::worker-results-${Environment}-${AWS::AccountId}"
                   - !Sub "arn:aws:s3:::processed-matrix-${Environment}-${AWS::AccountId}/*"
 
         - PolicyName: !Sub "can-upload-object-to-destination-bucket-${Environment}"


### PR DESCRIPTION
# Background
The trajectory analysis worker task need to download the embedding from S3. However, it turns out the worker doesn't have permissions to download items from `worker-results`. This PR adds that permission.

#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1938

#### Link to staging deployment URL

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR