### PR TITLE
[DRAFT] Use the same github action to get rds secrets in deploy-staigng and deploy-changed-cf

### DIFF
--- a/.github/workflows/deploy-changed-cf.yaml
+++ b/.github/workflows/deploy-changed-cf.yaml
@@ -251,25 +251,14 @@ jobs:
         with:
           string: ${{ matrix.environment-type }}
 
-      - id: get-rds-secrets
-        name: Export RDS secrets into environment variables
-        uses: abhilash1in/aws-secrets-manager-action@v2.0.0
+      - id: rds-secrets
+        uses: t-botz/aws-secrets-manager-read-action@v2
+        name: Outputs RDS secrets to get into the db
         with:
-          secrets: aurora-${{ matrix.environment-type }}
-          parse-json: true
-
-      - id: check-rds-secrets
-        name: Check RDS secrets are fetched
-        run: |-
-          # These checks if the RDS username and passwords are set
-          if [ -z $AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME ]; then
-            echo "RDS username not provided"
-            exit 1
-          fi
-          if [ -z $AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_PASSWORD ]; then
-            echo "RDS password not provided"
-            exit 1
-          fi
+          secret-id: aurora-${{ matrix.environment-type }}-default
+          mask-value: true
+          mask-json-values: true
+          keys-as-outputs: true
 
       - id: setup-rds-roles
         name: Setup RDS roles for default RDS instances
@@ -294,21 +283,21 @@ jobs:
             exit 1
           fi
           SETUP_ROLES_CMD="
-            PGPASSWORD=\'${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_PASSWORD}\' psql \
+            PGPASSWORD=\'${AURORA_PASSWORD}\' psql \
               --host=${RDSHOST} \
               --port=5432 \
-              --username=${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME} \
+              --username=${AURORA_USERNAME} \
               --dbname=aurora_db <<EOF
                 CREATE ROLE api_role WITH LOGIN;
                 CREATE ROLE dev_role WITH LOGIN;
                 GRANT USAGE ON SCHEMA public TO api_role;
                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public to api_role;
-                GRANT dev_role TO ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME};
+                GRANT dev_role TO ${AURORA_USERNAME};
                 ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO api_role;
                 ALTER DEFAULT PRIVILEGES FOR USER dev_role IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO api_role;
-                REVOKE dev_role FROM ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME};
+                REVOKE dev_role FROM ${AURORA_USERNAME};
                 GRANT rds_iam TO api_role;
-                GRANT rds_iam, ${AURORA_${{ steps.setup-rds-env.outputs.uppercase }}_USERNAME} TO dev_role;
+                GRANT rds_iam, ${AURORA_USERNAME} TO dev_role;
               EOF"
 
           aws ssm send-command --instance-ids "$INSTANCE_ID" \
@@ -316,6 +305,8 @@ jobs:
             --parameters "commands='$SETUP_ROLES_CMD'"
         env:
           REGION: ${{ secrets.AWS_REGION }}
+          AURORA_USERNAME: ${{ steps.rds-secrets.outputs.username }}
+          AURORA_PASSWORD: ${{ steps.rds-secrets.outputs.password }}
 
   report-if-failed:
     name: Report if workflow failed


### PR DESCRIPTION
# Background
Original: https://github.com/biomage-org/iac-old/pull/27

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR