### PR TITLE
[IVA'S PR] increase storing of non-concurrent versions to 14 days

### DIFF
--- a/cf/s3-v2.yaml
+++ b/cf/s3-v2.yaml
@@ -31,10 +31,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions are stored in normal S3 for
-          # 7 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 14
 
   CellSetsBucket:
     Type: AWS::S3::Bucket
@@ -55,10 +55,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions are stored in normal S3 for
-          # 7 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 14
 
   WorkerResultsBucket:
     Type: AWS::S3::Bucket
@@ -122,10 +122,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions are stored in normal S3 for
-          # 7 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 14
 
   # Stores, for each experiment and timestamp, the log and dump files for errors from the pipeline
   # Indexed by experimentId and timestamp
@@ -169,10 +169,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions of count matrices are stored in normal S3 for
-          # 5 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 5
+            NoncurrentVersionExpirationInDays: 14
 
   # Stores, for each experiment, the cellIds that were preserved after each filter step of the latest qc run
   # Indexed by experimentId
@@ -195,10 +195,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions are stored in normal S3 for
-          # 7 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 14
 
   BackupsBucket:
     Type: AWS::S3::Bucket
@@ -219,10 +219,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions of source files are stored in normal S3 for
-          # 7 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 7
+            NoncurrentVersionExpirationInDays: 14
           - Id: BackupRetentionDays
             Status: "Enabled"
             ExpirationInDays: 90
@@ -247,10 +247,10 @@ Resources:
       LifecycleConfiguration:
         Rules:
           # Non-current versions of source files are stored in normal S3 for
-          # 5 days and are then deleted.
+          # 14 days and are then deleted.
           - Id: PreserveThenDeleteNonCurrentVersion
             Status: "Enabled"
-            NoncurrentVersionExpirationInDays: 5
+            NoncurrentVersionExpirationInDays: 14
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:


### PR DESCRIPTION
# Background
https://github.com/biomage-org/iac-old/pull/128

#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with cellenics experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR