### PR TITLE
Add delete policy for staging s3 buckets

### DIFF
--- a/cf/developer-access-group.yaml
+++ b/cf/developer-access-group.yaml
@@ -54,7 +54,7 @@ Resources:
                   - "logs:PutQueryDefinition"
                   - "sns:Get*"
                   - "sns:List*"
-                Resource: "*" 
+                Resource: "*"
 
         - PolicyName: "can-create-xray-groups"
           PolicyDocument:
@@ -181,6 +181,16 @@ Resources:
                   - 's3:PutObject'
                 Resource:
                   - "arn:aws:s3:::cf-templates-*"
+
+        - PolicyName: "can-delete-from-staging-buckets"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 's3:DeleteObject'
+                Resource:
+                  - "arn:aws:s3:::*staging*/*"
 
         - PolicyName: "can-raise-support-questions"
           PolicyDocument:


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with cellenics experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR