### PR TITLE
Remove Agi and Jildou from cluster admins

### DIFF
--- a/deployment-config.json
+++ b/deployment-config.json
@@ -28,19 +28,16 @@
             "trv": {
                 "production": [
                     "ibabukova",
-                    "anugerahe",
                     "martinf",
                     "stefanb",
                     "polav",
                     "germans",
-                    "sarac",
-                    "jildoub"
+                    "sarac"
                 ]
             },
             "Biomage": {
                 "production": [
                     "ibabukova",
-                    "anugerahe",
                     "martinf",
                     "oliverg",
                     "stefanb",
@@ -48,12 +45,10 @@
                     "vickym",
                     "germans",
                     "sarac",
-                    "ci-users/testing/ci-user-testing",
-                    "jildoub"
+                    "ci-users/testing/ci-user-testing"
                 ],
                 "staging": [
                     "ibabukova",
-                    "anugerahe",
                     "martinf",
                     "oliverg",
                     "stefanb",
@@ -62,7 +57,6 @@
                     "germans",
                     "sarac",
                     "ci-users/testing/ci-user-testing",
-                    "jildoub",
                     "kristiana"
                 ]
             }


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
N/A

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with cellenics experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR