### PR TITLE
fix alb crds

### DIFF
--- a/.github/workflows/deploy-infra.yaml
+++ b/.github/workflows/deploy-infra.yaml
@@ -288,7 +288,8 @@ jobs:
           on_retry_command: sleep $(shuf -i 5-15 -n 1)
           command: |-
             helm repo add eks https://aws.github.io/eks-charts
-            kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+            wget https://raw.githubusercontent.com/aws/eks-charts/master/stable/aws-load-balancer-controller/crds/crds.yaml
+            kubectl apply -f crds.yaml
             helm repo update
             helm upgrade aws-load-balancer-controller eks/aws-load-balancer-controller \
               --namespace kube-system \


### PR DESCRIPTION
# Background

There seems to be an issue with a newer version of kubectl not being able to apply the aws-load-balancer-controller crds.yaml from github directory link (see [here](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3184)). Workaround (from [issue comment](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/3184#issuecomment-1701384830)) is to download the crds.yaml and apply locally. 

Causes create and configure action to hang:

![image](https://github.com/hms-dbmi-cellenics/iac/assets/15719520/19142aa1-0adc-423e-ba31-6d105d93479b)


#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with cellenics experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR