### PR TITLE
Fixing the scaling permission for the api

### DIFF
--- a/charts/nodejs/templates/scale-pods-right-to-api.yaml
+++ b/charts/nodejs/templates/scale-pods-right-to-api.yaml
@@ -1,4 +1,4 @@
-{{ if contains "api" .Values.biomageCi.repo }}
+{{ if and (contains "api" .Values.biomageCi.repo) (eq .Values.biomageCi.sandboxId "default") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,11 +7,13 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["update", "get"]
+{{ end }}
 ---
+{{ if contains "api" .Values.biomageCi.repo }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: api-can-scale-worker-pods
+  name: api-can-scale-worker-pods-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
# Background

ClusteringRole is defined for the whole cluster, so it needs to be defined only once (hence the new `default` if). On the other side, the `ClusteringRoleBinding` can be defined for multiple namespace but it needs to have a different name (hence adding the namespace to the binding name).

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with cellenics experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR