### PR TITLE
Remove Biomage and alabs envs and correct docker image account id

### DIFF
--- a/deployment-config.json
+++ b/deployment-config.json
@@ -2,26 +2,17 @@
     "biomage-org": {
         "domain_name": "Biomage",
         "environment_names": [
-            "alabs",
-            "Biomage",
             "trv"
         ],
         "docker_image_account": {
-            "id": 242905224710,
-            "region": "eu-west-1"
+            "id": 964743398471,
+            "region": "us-east-2"
         },
         "support_email": "engineering@biomage.net",
         "reply_email": "hello@biomage.net",
         "deployment_environments": {
             "trv": [
                 "production"
-            ],
-            "alabs": [
-                "production"
-            ],
-            "Biomage": [
-                "production",
-                "staging"
             ]
         },
         "cluster_admins": {
@@ -33,31 +24,6 @@
                     "polav",
                     "germans",
                     "sarac"
-                ]
-            },
-            "Biomage": {
-                "production": [
-                    "ibabukova",
-                    "martinf",
-                    "oliverg",
-                    "stefanb",
-                    "polav",
-                    "vickym",
-                    "germans",
-                    "sarac",
-                    "ci-users/testing/ci-user-testing"
-                ],
-                "staging": [
-                    "ibabukova",
-                    "martinf",
-                    "oliverg",
-                    "stefanb",
-                    "polav",
-                    "vickym",
-                    "germans",
-                    "sarac",
-                    "ci-users/testing/ci-user-testing",
-                    "kristiana"
                 ]
             }
         },

--- a/infra/config/github-environments-config.yaml
+++ b/infra/config/github-environments-config.yaml
@@ -1,12 +1,6 @@
-Biomage:
-  publicFacing: true
-  selfSignedCertificate: false
 HMS:
   publicFacing: true
   selfSignedCertificate: false
 trv:
   publicFacing: false
   selfSignedCertificate: true
-alabs:
-  publicFacing: false
-  selfSignedCertificate: false


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock  (with latest production data downloaded with cellenics experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/hms-dbmi-cellenics/cellenics-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR